### PR TITLE
Music Composer Refactor

### DIFF
--- a/Content/LETSGO/MusicEngine/BP_ComposerState.uasset
+++ b/Content/LETSGO/MusicEngine/BP_ComposerState.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fa6a2ac10841d5aa90bf3f5d2408d874b90ff0c474ebdd6e07b575d4b01358dd
+size 23018

--- a/Content/LETSGO/MusicEngine/BP_MusicComposer.uasset
+++ b/Content/LETSGO/MusicEngine/BP_MusicComposer.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4fce6591f03d4bfce01e3f47462ed24290e7601ebdcb41c2135d557111da2b30
+size 24473

--- a/Content/LETSGO/MusicEngine/BP_MusicComposerState.uasset
+++ b/Content/LETSGO/MusicEngine/BP_MusicComposerState.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6d86e3c26b13afca2d684183ad1263af71bf39e5c3e06f6e0a881b4aebfb1f8e
+size 24078

--- a/Content/LETSGO/MusicEngine/BP_MusicConductor.uasset
+++ b/Content/LETSGO/MusicEngine/BP_MusicConductor.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cde0a11f0fde736edf5754ff05f79f06e68f0fe27415406f082b1ee0cfd81577
-size 23087
+oid sha256:6e2d08a102b0d8f7c8f560c5a81cb0481ce40eeb7f873d910347affa7b8f4bea
+size 24284

--- a/Content/LETSGO/MusicEngine/BP_MusicConductor.uasset
+++ b/Content/LETSGO/MusicEngine/BP_MusicConductor.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cde0a11f0fde736edf5754ff05f79f06e68f0fe27415406f082b1ee0cfd81577
+size 23087

--- a/Content/LETSGO/Phases/BP_PhaseManager.uasset
+++ b/Content/LETSGO/Phases/BP_PhaseManager.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:dcfc529b93e3e1f3a9bfdf608b09972e137b13fb15ab51bb5ba34cbfe4eb8507
-size 25175
+oid sha256:b3fdf37c517bb314b1b79e3bc5d5d0dc56d84c4f77fe0b13174f99b6c1ef354f
+size 25401

--- a/Content/LETSGO/Phases/BP_StartMusicConductor.uasset
+++ b/Content/LETSGO/Phases/BP_StartMusicConductor.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ffcd2c17b9ad2417d95127da86f8ee10d5ac77b97c1f665c2f17493e24699914
+size 24283

--- a/Source/LETSGO/AudioPlatform/APlatformAudioCuePlayer.cpp
+++ b/Source/LETSGO/AudioPlatform/APlatformAudioCuePlayer.cpp
@@ -30,18 +30,18 @@ void APlatformAudioCuePlayer::BeginPlay()
 
 	// Set Instrument to play on next beat, defaults wait for next bar
 	Instrument->QuartzQuantizationBoundary = QuartzQuantizationBoundary;
-	Instrument-> RelativeQuantizationResolution = EQuartzCommandQuantization::Beat;
+	Instrument->RelativeQuantizationResolution = EQuartzCommandQuantization::Beat;
 	Instrument->RelativeQuantizationReference = EQuarztQuantizationReference::Count;
-	const FInstrumentSchedule Schedule = BuildInstrumentSchedule(AudioPlatformReference->Note.Note);
-	Instrument->Initialize(Schedule);
+	
 }
 
 void APlatformAudioCuePlayer::OnAudioPlatformTriggered(const FLetsGoMusicNotes IncomingNote)
 {
 	UE_LOG(LogLetsgo, Display, TEXT("AudioCuePlayer Recieved OnAudioPLatformTrigger"));
-
-	Instrument->StartPlaying();
 	
+	const FInstrumentSchedule Schedule = BuildInstrumentSchedule(IncomingNote.Note);
+	Instrument->InitializeSingleSchedule(Schedule);
+	Instrument->Initialize();
 }
 
 FInstrumentSchedule APlatformAudioCuePlayer::BuildInstrumentSchedule(TEnumAsByte<ELetsGoMusicNotes> ENote) const

--- a/Source/LETSGO/GameModes/ALetsGoGameMode.h
+++ b/Source/LETSGO/GameModes/ALetsGoGameMode.h
@@ -10,7 +10,8 @@
 #include "LETSGO/Phases/PhaseManager.h"
 #include "ALetsGoGameMode.generated.h"
 
-DECLARE_DYNAMIC_MULTICAST_DELEGATE(FMusicalStateUpdateDelegate);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE(FTonicSet);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FIntervalSet, int, Interval);
 
 /**
  * Custom Game Mode for LETSGO.
@@ -25,6 +26,9 @@ class LETSGO_API ALetsGoGameMode : public AGameModeBase
 	GENERATED_BODY()
 
 public:
+	UPROPERTY()
+	ALetsGoGameState* State;
+	
 	UPROPERTY(BlueprintReadWrite, EditDefaultsOnly, Category="LETSGO | Audio Platform Spawner")
 	TSubclassOf<APhaseManager> PhaseManagerClass;
 
@@ -32,7 +36,10 @@ public:
 	APhaseManager* PhaseManager;
 
 	UPROPERTY()
-	FMusicalStateUpdateDelegate OnMusicalStateUpdated;
+	FTonicSet OnTonicSet;
+
+	UPROPERTY()
+	FIntervalSet OnIntervalSet;
 
 protected:
 	// Called when the game starts or when spawned
@@ -41,6 +48,7 @@ protected:
 public:
 	ALetsGoGameMode();
 
+
 	// MUSICAL STATE
 	// Tonic
 	UFUNCTION(BlueprintCallable, Category="LETSGO")
@@ -48,51 +56,14 @@ public:
 
 	UFUNCTION(BlueprintCallable, Category="LETSGO")
 	FLetsGoMusicNotes GetTonic() const; 
-
-	// Second
-	UFUNCTION(BlueprintCallable, Category="LETSGO")
-	void SetSecond(FLetsGoMusicNotes Note) const;
-
-	UFUNCTION(BlueprintCallable, Category="LETSGO")
-	FLetsGoMusicNotes GetSecond() const; 
 	
-	// Third
 	UFUNCTION(BlueprintCallable, Category="LETSGO")
-	void SetThird(FLetsGoMusicNotes Note) const;
-
-	UFUNCTION(BlueprintCallable, Category="LETSGO")
-	FLetsGoMusicNotes GetThird() const;
-
-	// Fourth
-	UFUNCTION(BlueprintCallable, Category="LETSGO")
-	void SetFourth(FLetsGoMusicNotes Note) const;
+	FLetsGoGeneratedScale GetChromaticScale() const;
 
 	UFUNCTION(BlueprintCallable, Category="LETSGO")
-	FLetsGoMusicNotes GetFourth() const; 
+	void SetInterval(int Interval) const;
 
-	// Fifth
-	UFUNCTION(BlueprintCallable, Category="LETSGO")
-	void SetFifth(FLetsGoMusicNotes Note) const;
-
-	UFUNCTION(BlueprintCallable, Category="LETSGO")
-	FLetsGoMusicNotes GetFifth() const;
-
-	// Sixth
-	UFUNCTION(BlueprintCallable, Category="LETSGO")
-	void SetSixth(FLetsGoMusicNotes Note) const;
-
-	UFUNCTION(BlueprintCallable, Category="LETSGO")
-	FLetsGoMusicNotes GetSixth() const;
-
-	// Seventh
-	UFUNCTION(BlueprintCallable, Category="LETSGO")
-	void SetSeventh(FLetsGoMusicNotes Note) const;
-
-	UFUNCTION(BlueprintCallable, Category="LETSGO")
-	FLetsGoMusicNotes GetSeventh() const; 
-
-
-
+	
 	
 	// Clock
 	UFUNCTION(BlueprintCallable, Category="LETSGO")

--- a/Source/LETSGO/GameModes/ALetsGoGameState.h
+++ b/Source/LETSGO/GameModes/ALetsGoGameState.h
@@ -30,28 +30,14 @@ public:
 	UPROPERTY(VisibleAnywhere, Category = "LETSGO")  
 	AClockSettings* ClockSettings;
 
-	// Generated Notes 
+	UPROPERTY(VisibleAnywhere, Category= "LETSGO")
+	bool IsTonicSet = false;
+	
 	UPROPERTY(VisibleAnywhere, Category= "LETSGO")
 	FLetsGoMusicNotes Tonic;
 
 	UPROPERTY(VisibleAnywhere, Category= "LETSGO")
-	FLetsGoMusicNotes Second;
-	
-	UPROPERTY(VisibleAnywhere, Category= "LETSGO")
-	FLetsGoMusicNotes Third;
-
-	UPROPERTY(VisibleAnywhere, Category= "LETSGO")
-	FLetsGoMusicNotes Fourth;
-
-	UPROPERTY(VisibleAnywhere, Category= "LETSGO")
-	FLetsGoMusicNotes Fifth;
-
-	UPROPERTY(VisibleAnywhere, Category= "LETSGO")
-	FLetsGoMusicNotes Sixth;
-
-	UPROPERTY(VisibleAnywhere, Category= "LETSGO")
-	FLetsGoMusicNotes Seventh;
-
+	FLetsGoGeneratedScale ChromaticScale;
 	
 	UPROPERTY(VisibleAnywhere, Category= "LETSGO")
 	UInstrumentRack* InstrumentRack;

--- a/Source/LETSGO/Instruments/Instrument.cpp
+++ b/Source/LETSGO/Instruments/Instrument.cpp
@@ -121,9 +121,7 @@ void AInstrument::OnQuantizationBoundaryTriggered(FName ClockName, EQuartzComman
 			GEngine->AddOnScreenDebugMessage(-1, 15.0f, FColor::Yellow, FString::Printf(TEXT("Current Bar [%i], StartAtBar [%i]"), CurrentBar, InstrumentSchedule.StartAtBar ));
 	}
 
-	const int CurrentScheduleEnds = CurrentBar + (InstrumentSchedule.BeatSchedule.Num() - 1);
 	const int CurrentRelativeBar = CurrentBar - InstrumentSchedule.StartAtBar;
-	const int RelativeEnd = CurrentBar - InstrumentSchedule.BeatSchedule.Num() - 1;
 	const int AbsoluteEnd = InstrumentSchedule.StartAtBar + InstrumentSchedule.BeatSchedule.Num() - 1;
 
 	if (CurrentBar <= AbsoluteEnd)

--- a/Source/LETSGO/Instruments/Instrument.cpp
+++ b/Source/LETSGO/Instruments/Instrument.cpp
@@ -87,6 +87,11 @@ void AInstrument::PlayBar(const int BarIndexToPlay, const FInstrumentSchedule& I
 	
 	const FPerBarSchedule BarSchedule = InstrumentSchedule.BeatSchedule[BarIndexToPlay];
 
+	/*
+	if(GEngine)
+		GEngine->AddOnScreenDebugMessage(-1, 15.0f, FColor::Purple, FString::Printf(TEXT("Playing Bar [%i]"), BarIndexToPlay));
+	*/
+	
 	for (int i = 0; i < BarSchedule.NotesInBar.Num(); i++)
 	{
 		const FNotesPerBar Notes = BarSchedule.NotesInBar[i];
@@ -111,20 +116,27 @@ void AInstrument::OnQuantizationBoundaryTriggered(FName ClockName, EQuartzComman
                                                   int32 NumBars, int32 Beat, float BeatFraction)
 {
 	if (InstrumentSchedules->Num() == 0)
+	{
 		return;
+	}
 
 	const FInstrumentSchedule InstrumentSchedule = (*InstrumentSchedules)[InstrumentScheduleIndex];
 
+	/*
+	if(GEngine)
+		GEngine->AddOnScreenDebugMessage(-1, 15.0f, FColor::Yellow, FString::Printf(TEXT("InstrumentSchedules [%i]"), InstrumentSchedules->Num()));
+	*/
+
+	
 	if (InstrumentSchedule.StartAtBar < CurrentBar)
 	{
-		if(GEngine)
-			GEngine->AddOnScreenDebugMessage(-1, 15.0f, FColor::Yellow, FString::Printf(TEXT("Current Bar [%i], StartAtBar [%i]"), CurrentBar, InstrumentSchedule.StartAtBar ));
+		UE_LOG(LogLetsgo, Error, TEXT("Instrument StartAtBar < Current Bar"))
 	}
 
 	const int CurrentRelativeBar = CurrentBar - InstrumentSchedule.StartAtBar;
 	const int AbsoluteEnd = InstrumentSchedule.StartAtBar + InstrumentSchedule.BeatSchedule.Num() - 1;
 
-	if (CurrentBar <= AbsoluteEnd)
+	if (CurrentRelativeBar >= 0 && CurrentBar <= AbsoluteEnd)
 	{
 		PlayBar(CurrentRelativeBar, InstrumentSchedule);
 	}

--- a/Source/LETSGO/Instruments/Instrument.cpp
+++ b/Source/LETSGO/Instruments/Instrument.cpp
@@ -45,11 +45,12 @@ void AInstrument::Tick(float DeltaTime)
 	Super::Tick(DeltaTime);
 }
 
-void AInstrument::Initialize(const FInstrumentSchedule& Schedule)
+void AInstrument::Initialize(const FInstrumentSchedule& Schedule, const bool IsRepeating)
 {
 	SetClock();
 	InstrumentSchedule = Schedule;
 	RelativeQuantizationResolution = Schedule.QuantizationDivision;
+	Repeat = IsRepeating;
 }
 
 void AInstrument::StartPlaying()
@@ -90,7 +91,10 @@ void AInstrument::OnQuantizationBoundaryTriggered(FName ClockName, EQuartzComman
 
 	if (CurrentBar == InstrumentSchedule.BeatSchedule.Num() - 1)
 	{
-		CurrentBar = 0;
+		if (Repeat)
+			CurrentBar = 0;
+
+		//TODO Add logic to destroy after play
 	}
 	else
 	{

--- a/Source/LETSGO/Instruments/Instrument.cpp
+++ b/Source/LETSGO/Instruments/Instrument.cpp
@@ -72,7 +72,7 @@ void AInstrument::InitializeSingleSchedule(const FInstrumentSchedule& Schedule)
 	InstrumentSchedules = MakeShared<TArray<FInstrumentSchedule>>(Schedules) ;
 }
 
-void AInstrument::InitializeMultipleSchedules(const TSharedPtr<TArray<FInstrumentSchedule>>& Schedules)
+void AInstrument::InitializeMultipleSchedules(TSharedPtr<TArray<FInstrumentSchedule>> Schedules)
 {
 	InstrumentSchedules = Schedules;
 }

--- a/Source/LETSGO/Instruments/Instrument.h
+++ b/Source/LETSGO/Instruments/Instrument.h
@@ -43,7 +43,7 @@ public:
 	};
 	
 	
-	TArray<TSharedPtr<FInstrumentSchedule>> InstrumentSchedules;
+	TSharedPtr<TArray<FInstrumentSchedule>> InstrumentSchedules;
 
 	int InstrumentScheduleIndex = 0;
 	
@@ -68,7 +68,7 @@ protected:
 	virtual void BeginDestroy() override;
 
 	void InitializeClock();
-	void PlayBar(int BarIndexToPlay, const TSharedPtr<FInstrumentSchedule>& InstrumentSchedule);
+	void PlayBar(int BarIndexToPlay, const FInstrumentSchedule& InstrumentSchedule);
 	
 public:
 	// Called every frame
@@ -80,7 +80,7 @@ public:
 	UFUNCTION()
 	void InitializeSingleSchedule(const FInstrumentSchedule& Schedule);
 
-	void InitializeMultipleSchedules(const TArray<TSharedPtr<FInstrumentSchedule>>& Schedules);
+	void InitializeMultipleSchedules(const TSharedPtr<TArray<FInstrumentSchedule>>& Schedules);
 	
 
 	/**

--- a/Source/LETSGO/Instruments/Instrument.h
+++ b/Source/LETSGO/Instruments/Instrument.h
@@ -41,16 +41,18 @@ public:
 		EQuarztQuantizationReference::BarRelative,
 		true
 	};
+	
+	
+	TArray<TSharedPtr<FInstrumentSchedule>> InstrumentSchedules;
 
-	UPROPERTY()
-	FInstrumentSchedule InstrumentSchedule;
-
+	int InstrumentScheduleIndex = 0;
+	
 	UPROPERTY()
 	int CurrentBar = 0;
 
 	UPROPERTY()
 	bool Repeat = false;
-
+	
 	UPROPERTY()
 	EQuartzCommandQuantization RelativeQuantizationResolution;
 
@@ -63,22 +65,24 @@ public:
 protected:
 	// Called when the game starts or when spawned
 	virtual void BeginPlay() override;
+	virtual void BeginDestroy() override;
 
-	void SetClock();
-
+	void InitializeClock();
+	void PlayBar(int BarIndexToPlay, const TSharedPtr<FInstrumentSchedule>& InstrumentSchedule);
+	
 public:
 	// Called every frame
 	virtual void Tick(float DeltaTime) override;
 
 	UFUNCTION()
-	void Initialize(const FInstrumentSchedule& Schedule, const bool IsRepeating = false);
-	
-	UFUNCTION()
-	void StartPlaying();
+	void Initialize(const bool IsRepeating = false, const int InCurrentBar = 0);
 
 	UFUNCTION()
-	void StopPlaying();
+	void InitializeSingleSchedule(const FInstrumentSchedule& Schedule);
+
+	void InitializeMultipleSchedules(const TArray<TSharedPtr<FInstrumentSchedule>>& Schedules);
 	
+
 	/**
 	 * Function intended to trigger on Clock Quantization Subscription event
 	 * ie. Fire this function on every Beat
@@ -91,5 +95,7 @@ public:
 	 */
 	UFUNCTION()
 	void OnQuantizationBoundaryTriggered(FName ClockName, EQuartzCommandQuantization QuantizationType, int32 NumBars, int32 Beat, float BeatFraction);
-	
+
+	UFUNCTION()
+	void InitiateDestroy();
 };

--- a/Source/LETSGO/Instruments/Instrument.h
+++ b/Source/LETSGO/Instruments/Instrument.h
@@ -6,7 +6,6 @@
 #include "AudioCuePlayer.h"
 #include "GameFramework/Actor.h"
 #include "Quartz/AudioMixerClockHandle.h"
-#include "MetasoundSource.h"
 #include "LETSGO/Instruments/InstrumentSchedule.h"
 #include "LETSGO/MusicEngine/ClockSettings.h"
 #include "Instrument.generated.h"
@@ -80,7 +79,7 @@ public:
 	UFUNCTION()
 	void InitializeSingleSchedule(const FInstrumentSchedule& Schedule);
 
-	void InitializeMultipleSchedules(const TSharedPtr<TArray<FInstrumentSchedule>>& Schedules);
+	void InitializeMultipleSchedules(TSharedPtr<TArray<FInstrumentSchedule>> Schedules);
 	
 
 	/**

--- a/Source/LETSGO/Instruments/Instrument.h
+++ b/Source/LETSGO/Instruments/Instrument.h
@@ -49,6 +49,9 @@ public:
 	int CurrentBar = 0;
 
 	UPROPERTY()
+	bool Repeat = false;
+
+	UPROPERTY()
 	EQuartzCommandQuantization RelativeQuantizationResolution;
 
 	UPROPERTY()
@@ -68,7 +71,7 @@ public:
 	virtual void Tick(float DeltaTime) override;
 
 	UFUNCTION()
-	void Initialize(const FInstrumentSchedule& Schedule);
+	void Initialize(const FInstrumentSchedule& Schedule, const bool IsRepeating = false);
 	
 	UFUNCTION()
 	void StartPlaying();

--- a/Source/LETSGO/Instruments/InstrumentSchedule.cpp
+++ b/Source/LETSGO/Instruments/InstrumentSchedule.cpp
@@ -19,3 +19,14 @@ FInstrumentSchedule::FInstrumentSchedule(const EQuartzCommandQuantization Quanti
 	BeatSchedule = Pattern;
 }
 
+FInstrumentSchedule::FInstrumentSchedule(const EQuartzCommandQuantization Quantization,
+	const FPerBarSchedule& Pattern, const int TimesToRepeat, const int BarStart)
+{
+	QuantizationDivision = Quantization;
+	StartAtBar = BarStart;
+	for (int i = 0; i < TimesToRepeat; i++)
+	{
+		BeatSchedule.Emplace(Pattern);
+	}
+}
+

--- a/Source/LETSGO/Instruments/InstrumentSchedule.cpp
+++ b/Source/LETSGO/Instruments/InstrumentSchedule.cpp
@@ -17,6 +17,5 @@ FInstrumentSchedule::FInstrumentSchedule(const EQuartzCommandQuantization Quanti
 {
 	QuantizationDivision = Quantization;
 	BeatSchedule = Pattern;
-	IsValid = true;
 }
 

--- a/Source/LETSGO/Instruments/InstrumentSchedule.h
+++ b/Source/LETSGO/Instruments/InstrumentSchedule.h
@@ -49,9 +49,6 @@ struct FInstrumentSchedule
 	UPROPERTY()
 	TArray<FPerBarSchedule> BeatSchedule; // [[1,3],[1,3],[1,3],[1,2,3,4]] play 1-3, on 4th bar 4onfloor
 
-	UPROPERTY()
-	bool IsValid = false;
-
 	FInstrumentSchedule(): QuantizationDivision() {} ;
 	explicit FInstrumentSchedule(const EQuartzCommandQuantization Quantization, const TArray<FPerBarSchedule>& Pattern);
 

--- a/Source/LETSGO/Instruments/InstrumentSchedule.h
+++ b/Source/LETSGO/Instruments/InstrumentSchedule.h
@@ -42,6 +42,9 @@ USTRUCT()
 struct FInstrumentSchedule
 {
 	GENERATED_BODY()
+
+	UPROPERTY()
+	int StartAtBar = 0;
 	
 	UPROPERTY()
 	EQuartzCommandQuantization QuantizationDivision;
@@ -50,6 +53,8 @@ struct FInstrumentSchedule
 	TArray<FPerBarSchedule> BeatSchedule; // [[1,3],[1,3],[1,3],[1,2,3,4]] play 1-3, on 4th bar 4onfloor
 
 	FInstrumentSchedule(): QuantizationDivision() {} ;
+
 	explicit FInstrumentSchedule(const EQuartzCommandQuantization Quantization, const TArray<FPerBarSchedule>& Pattern);
+	explicit FInstrumentSchedule(const EQuartzCommandQuantization Quantization, const FPerBarSchedule& Pattern, const int TimesToRepeat, const int BarStart);
 
 };

--- a/Source/LETSGO/MusicEngine/MusicComposition/ComposerData.cpp
+++ b/Source/LETSGO/MusicEngine/MusicComposition/ComposerData.cpp
@@ -3,10 +3,9 @@
 
 FComposerData::FComposerData(const EInstrumentRoles InRole, const FInstrumentData& InData)
 {
-	FComposerData();
 	InstrumentRole = InRole;
 	InstrumentData = InData;
-
+	ScheduleData = MakeShared<TArray<FInstrumentSchedule>>();
 }
 
 bool FComposerData::IsMultiNoteInstrument() const
@@ -35,7 +34,7 @@ int FComposerData::GetBarsDefined() const
 
 void FComposerData::EmplaceScheduleData(FInstrumentSchedule Schedule)
 {
-	ScheduleData.Emplace(Schedule);
+	ScheduleData->Emplace(Schedule);
 	BarsDefined = Schedule.StartAtBar + Schedule.BeatSchedule.Num();
 }
 

--- a/Source/LETSGO/MusicEngine/MusicComposition/ComposerData.cpp
+++ b/Source/LETSGO/MusicEngine/MusicComposition/ComposerData.cpp
@@ -28,6 +28,17 @@ bool FComposerData::IsMultiNoteInstrument() const
 	}
 }
 
+int FComposerData::GetBarsDefined() const
+{
+	return BarsDefined;
+}
+
+void FComposerData::EmplaceScheduleData(FInstrumentSchedule Schedule)
+{
+	ScheduleData.Emplace(Schedule);
+	BarsDefined = Schedule.StartAtBar + Schedule.BeatSchedule.Num();
+}
+
 /*
 FInstrumentInputData::FInstrumentInputData(const FComposerData& InputData)
 {

--- a/Source/LETSGO/MusicEngine/MusicComposition/ComposerData.cpp
+++ b/Source/LETSGO/MusicEngine/MusicComposition/ComposerData.cpp
@@ -40,7 +40,7 @@ FMusicStrategyData::FMusicStrategyData(): Strategy(nullptr)
 }
 */
 
-FMusicStrategyData::FMusicStrategyData()
+/*FMusicStrategyData::FMusicStrategyData()
 {
 }
 
@@ -50,7 +50,7 @@ FMusicStrategyData::FMusicStrategyData(IMusicStrategy* InputStrategy, const floa
 	Strategy = InputStrategy;
 	StrategyAppropriateness = Appropriateness;
 	StrategyType = InStrategyType;
-}
+}*/
 
 /*
 void FMusicStrategyData::GenerateInstrumentInputs(const TArray<FComposerData> ComposerDataSet)

--- a/Source/LETSGO/MusicEngine/MusicComposition/ComposerData.cpp
+++ b/Source/LETSGO/MusicEngine/MusicComposition/ComposerData.cpp
@@ -28,15 +28,6 @@ bool FComposerData::IsMultiNoteInstrument() const
 	}
 }
 
-FInstrumentScheduleData::FInstrumentScheduleData(const FInstrumentSchedule& Schedule, const int InStartAtBars, const int InTimesToRepeat)
-{
-	InstrumentSchedule = Schedule;
-	StartAtBar = InStartAtBars;
-	TimesToRepeat = InTimesToRepeat;
-
-	IsValid = true;
-}
-
 /*
 FInstrumentInputData::FInstrumentInputData(const FComposerData& InputData)
 {

--- a/Source/LETSGO/MusicEngine/MusicComposition/ComposerData.h
+++ b/Source/LETSGO/MusicEngine/MusicComposition/ComposerData.h
@@ -27,7 +27,7 @@ enum EInstrumentRoles
 	Clap,
 };
 
-UENUM()
+/*UENUM()
 enum EMusicStrategies
 {
 	PedalPoint,
@@ -47,16 +47,12 @@ struct FMusicStrategyData
 	UPROPERTY()
 	float StrategyAppropriateness = 0.0f;
 
-	// TArray<FInstrumentInputData> InstrumentInputs;
-
 
 	FMusicStrategyData();
 	FMusicStrategyData(IMusicStrategy* InputStrategy, float Appropriateness, const EMusicStrategies InStrategyType);
+};*/
 
-	// void GenerateInstrumentInputs(const TArray<FComposerData> ComposerDataSet);
-};
-
-// Wraps InstrumentSchedule with data specific for Composer. 
+/*// Wraps InstrumentSchedule with data specific for Composer. 
 USTRUCT()
 struct FInstrumentScheduleData
 {
@@ -64,18 +60,9 @@ struct FInstrumentScheduleData
 
 	UPROPERTY()
 	FInstrumentSchedule InstrumentSchedule;
-
-	UPROPERTY()
-	int StartAtBar = 0;
-
-	UPROPERTY()
-	int TimesToRepeat = 0;
-
+	
 	UPROPERTY()
 	FMusicStrategyData StrategyData;
-
-	UPROPERTY()
-	bool IsValid = false;
 
 	FInstrumentScheduleData()
 	{
@@ -85,37 +72,14 @@ struct FInstrumentScheduleData
 	FInstrumentScheduleData(const FInstrumentSchedule& Schedule, int InStartAtBars, int InTimesToRepeat)
 	{
 		InstrumentSchedule = Schedule;
-		StartAtBar = InStartAtBars;
-		TimesToRepeat = InTimesToRepeat;
-
-		IsValid = true;
 	}
-};
-
-// Represents another Instrument that may be influential to a Musical Strategy
-// eg. A `Call and Response` strat needs instruments to listen to each other.
-// This object facilitates the data needed for such a strategy.
-/*USTRUCT()
-struct FInstrumentInputData
-{
-	GENERATED_BODY()
-
-	FComposerData ComposerData;
-	float Appropriateness = 0.0f;
-
-	FInstrumentInputData() {}
-	explicit FInstrumentInputData(const FComposerData& InputData);
 };*/
-
 
 
 USTRUCT()
 struct FComposerData
 {
 	GENERATED_BODY()
-
-	UPROPERTY()
-	FLetsGoGeneratedScale Scale; 
 
 	UPROPERTY()
 	TEnumAsByte<EInstrumentRoles> InstrumentRole = None;
@@ -130,14 +94,11 @@ struct FComposerData
 	int OctaveMax = 5;
 
 	UPROPERTY()
-	TArray<FInstrumentScheduleData> ScheduleData;
-
-	// IMusicCompositionStrategy* CompositionStrategy;
-	// int ComposerDataObjectIndex;
+	TArray<FInstrumentSchedule> ScheduleData;
 
 	FComposerData()
 	{
-		ScheduleData = TArray<FInstrumentScheduleData>();
+		ScheduleData = TArray<FInstrumentSchedule>();
 	}
 
 	explicit FComposerData(const EInstrumentRoles InRole, const FInstrumentData& InData);

--- a/Source/LETSGO/MusicEngine/MusicComposition/ComposerData.h
+++ b/Source/LETSGO/MusicEngine/MusicComposition/ComposerData.h
@@ -82,9 +82,15 @@ struct FInstrumentScheduleData
 		UE_LOG(LogLetsgo, Warning, TEXT("Default FInstrumentScheduleData Constructor used."));
 	}
 
-	FInstrumentScheduleData(const FInstrumentSchedule& Schedule, int InStartAtBars, int InTimesToRepeat);
-};
+	FInstrumentScheduleData(const FInstrumentSchedule& Schedule, int InStartAtBars, int InTimesToRepeat)
+	{
+		InstrumentSchedule = Schedule;
+		StartAtBar = InStartAtBars;
+		TimesToRepeat = InTimesToRepeat;
 
+		IsValid = true;
+	}
+};
 
 // Represents another Instrument that may be influential to a Musical Strategy
 // eg. A `Call and Response` strat needs instruments to listen to each other.

--- a/Source/LETSGO/MusicEngine/MusicComposition/ComposerData.h
+++ b/Source/LETSGO/MusicEngine/MusicComposition/ComposerData.h
@@ -1,6 +1,5 @@
 ﻿#pragma once
 
-#include "LETSGO/Instruments/Instrument.h"
 #include "LETSGO/Instruments/InstrumentNote.h"
 #include "LETSGO/Instruments/InstrumentSchedule.h"
 #include "ComposerData.generated.h"
@@ -24,55 +23,6 @@ enum EInstrumentRoles
 	Clap,
 };
 
-/*UENUM()
-enum EMusicStrategies
-{
-	PedalPoint,
-	CreateMotif,
-};
-
-USTRUCT()
-struct FMusicStrategyData
-{
-	GENERATED_BODY()
-
-	IMusicStrategy* Strategy;
-
-	UPROPERTY()
-	TEnumAsByte<EMusicStrategies> StrategyType;
-
-	UPROPERTY()
-	float StrategyAppropriateness = 0.0f;
-
-
-	FMusicStrategyData();
-	FMusicStrategyData(IMusicStrategy* InputStrategy, float Appropriateness, const EMusicStrategies InStrategyType);
-};*/
-
-/*// Wraps InstrumentSchedule with data specific for Composer. 
-USTRUCT()
-struct FInstrumentScheduleData
-{
-	GENERATED_BODY()
-
-	UPROPERTY()
-	FInstrumentSchedule InstrumentSchedule;
-	
-	UPROPERTY()
-	FMusicStrategyData StrategyData;
-
-	FInstrumentScheduleData()
-	{
-		UE_LOG(LogLetsgo, Warning, TEXT("Default FInstrumentScheduleData Constructor used."));
-	}
-
-	FInstrumentScheduleData(const FInstrumentSchedule& Schedule, int InStartAtBars, int InTimesToRepeat)
-	{
-		InstrumentSchedule = Schedule;
-	}
-};*/
-
-
 USTRUCT()
 struct FComposerData
 {
@@ -89,15 +39,12 @@ struct FComposerData
 
 	UPROPERTY()
 	int OctaveMax = 5;
-
-	UPROPERTY()
-	AInstrument* Instrument; 
 	
-	TArray<FInstrumentSchedule> ScheduleData;
+	TSharedPtr<TArray<FInstrumentSchedule>> ScheduleData;
 
 	FComposerData()
 	{
-		ScheduleData = TArray<FInstrumentSchedule>();
+		ScheduleData = MakeShared<TArray<FInstrumentSchedule>>();
 	}
 
 	int BarsDefined = 0;

--- a/Source/LETSGO/MusicEngine/MusicComposition/ComposerData.h
+++ b/Source/LETSGO/MusicEngine/MusicComposition/ComposerData.h
@@ -1,11 +1,8 @@
 ﻿#pragma once
 
-#include "MusicStrategy.h"
-#include "LETSGO/LETSGO.h"
 #include "LETSGO/Instruments/Instrument.h"
 #include "LETSGO/Instruments/InstrumentNote.h"
 #include "LETSGO/Instruments/InstrumentSchedule.h"
-#include "LETSGO/MusicEngine/ULetsGoMusicEngine.h"
 #include "ComposerData.generated.h"
 
 UENUM()
@@ -94,11 +91,13 @@ struct FComposerData
 	int OctaveMax = 5;
 
 	UPROPERTY()
-	TArray<FInstrumentSchedule> ScheduleData;
+	AInstrument* Instrument; 
+	
+	TArray<TSharedPtr<FInstrumentSchedule>> ScheduleData;
 
 	FComposerData()
 	{
-		ScheduleData = TArray<FInstrumentSchedule>();
+		ScheduleData = TArray<TSharedPtr<FInstrumentSchedule>>();
 	}
 
 	explicit FComposerData(const EInstrumentRoles InRole, const FInstrumentData& InData);

--- a/Source/LETSGO/MusicEngine/MusicComposition/ComposerData.h
+++ b/Source/LETSGO/MusicEngine/MusicComposition/ComposerData.h
@@ -93,11 +93,11 @@ struct FComposerData
 	UPROPERTY()
 	AInstrument* Instrument; 
 	
-	TArray<TSharedPtr<FInstrumentSchedule>> ScheduleData;
+	TArray<FInstrumentSchedule> ScheduleData;
 
 	FComposerData()
 	{
-		ScheduleData = TArray<TSharedPtr<FInstrumentSchedule>>();
+		ScheduleData = TArray<FInstrumentSchedule>();
 	}
 
 	explicit FComposerData(const EInstrumentRoles InRole, const FInstrumentData& InData);

--- a/Source/LETSGO/MusicEngine/MusicComposition/ComposerData.h
+++ b/Source/LETSGO/MusicEngine/MusicComposition/ComposerData.h
@@ -100,7 +100,13 @@ struct FComposerData
 		ScheduleData = TArray<FInstrumentSchedule>();
 	}
 
+	int BarsDefined = 0;
+	
 	explicit FComposerData(const EInstrumentRoles InRole, const FInstrumentData& InData);
 
 	bool IsMultiNoteInstrument() const;
+
+	int GetBarsDefined() const;
+
+	void EmplaceScheduleData(FInstrumentSchedule);
 };

--- a/Source/LETSGO/MusicEngine/MusicComposition/MusicComposer.cpp
+++ b/Source/LETSGO/MusicEngine/MusicComposition/MusicComposer.cpp
@@ -28,8 +28,6 @@ void AMusicComposer::BeginDestroy()
 	if (Clock)
 		Clock->StopClock(GetWorld(), true, Clock);
 
-	ComposerState->ComposerDataObjects.Empty();
-	
 	Super::BeginDestroy();
 }
 
@@ -128,7 +126,7 @@ void AMusicComposer::InitializeStrategies()
 	};
 }
 
-IMusicStrategy* AMusicComposer::ChooseMusicalStrategy(const TSharedPtr<FComposerData>& ComposerData, float& AppropriatenessOut)
+IMusicStrategy* AMusicComposer::ChooseMusicalStrategy(const FComposerData& ComposerData, float& AppropriatenessOut)
 {
 	IMusicStrategy* ChosenStrategy = MusicalStrategies[0];
 
@@ -147,7 +145,7 @@ IMusicStrategy* AMusicComposer::ChooseMusicalStrategy(const TSharedPtr<FComposer
 	return ChosenStrategy;
 }
 
-FInstrumentSchedule AMusicComposer::GenerateBars(TSharedPtr<FComposerData>& ComposerData, IMusicStrategy* ChosenStrategy, const int StartAtBar, const int TimesToRepeat)
+FInstrumentSchedule AMusicComposer::GenerateBars(FComposerData& ComposerData, IMusicStrategy* ChosenStrategy, const int StartAtBar, const int TimesToRepeat)
 {
 	FPerBarSchedule Bar = ChosenStrategy->GenerateBar(ComposerData, ComposerState);
 	FInstrumentSchedule InstrumentSchedule = FInstrumentSchedule(EQuartzCommandQuantization::QuarterNote, Bar, TimesToRepeat, StartAtBar);
@@ -162,12 +160,12 @@ void AMusicComposer::CheckAndGenerateBars(const int32 CurrentBar)
 	// Does this ComposerData need more bars defined? 
 	for (int i = 0; i < ComposerState->ComposerDataObjects.Num(); i++ )
 	{
-		TSharedPtr<FComposerData> ComposerData = MakeShared<FComposerData>(ComposerState->ComposerDataObjects[i]);
+		FComposerData ComposerData = ComposerState->ComposerDataObjects[i];
 
 		// Peer into each ComposerDatas InstrumentSchedules to determine how many bars we have
-		for(int ScheduleIndex = 0; ScheduleIndex < ComposerData->ScheduleData.Num(); ScheduleIndex++)
+		for(int ScheduleIndex = 0; ScheduleIndex < ComposerData.ScheduleData.Num(); ScheduleIndex++)
 		{
-			const TSharedPtr<FInstrumentSchedule> ScheduleData = ComposerData->ScheduleData[ScheduleIndex];
+			const TSharedPtr<FInstrumentSchedule> ScheduleData = ComposerData.ScheduleData[ScheduleIndex];
 			if(const int32 BarSchedule = ScheduleData->StartAtBar * ScheduleData->BeatSchedule.Num(); BarSchedule > BarsDefined)
 			{
 				BarsDefined = BarSchedule;

--- a/Source/LETSGO/MusicEngine/MusicComposition/MusicComposer.cpp
+++ b/Source/LETSGO/MusicEngine/MusicComposition/MusicComposer.cpp
@@ -36,7 +36,20 @@ void AMusicComposer::Tick(float DeltaTime)
 {
 	Super::Tick(DeltaTime);
 
-	if (ComposerState->CurrentBar > LastProcessedBar)
+	if (! ComposerState->IsTonicSet)
+		return;
+	
+	int StartAtBar = ComposerState->CurrentBar;
+
+	if (! Started)
+	{
+		StartAtBar += 2;
+		Started = true;
+		if(GEngine)
+			GEngine->AddOnScreenDebugMessage(-1, 15.0f, FColor::Yellow, FString::Printf(TEXT("Started")));
+	}
+	
+	if (StartAtBar > LastProcessedBar)
 	{
 		CheckAndGenerateBars();
 		LastProcessedBar = ComposerState->CurrentBar;
@@ -169,7 +182,8 @@ void AMusicComposer::CheckAndGenerateBars()
 	{
 		FComposerData ComposerData = ComposerState->ComposerDataObjects[i];
 
-		// Peer into each ComposerDatas InstrumentSchedules to determine how many bars we have
+		
+		/*// Peer into each ComposerDatas InstrumentSchedules to determine how many bars we have
 		for(int ScheduleIndex = 0; ScheduleIndex < ComposerData.ScheduleData.Num(); ScheduleIndex++)
 		{
 			const FInstrumentSchedule ScheduleData = ComposerData.ScheduleData[ScheduleIndex];
@@ -177,10 +191,10 @@ void AMusicComposer::CheckAndGenerateBars()
 			{
 				BarsDefined = BarSchedule;
 			}
-		}
+		}*/
 
 		// Define bars for this instrument
-		if (BarsDefined - ComposerState->CurrentBar < ComposerState->BarCreationThreshold)
+		if (ComposerData.BarsDefined - ComposerState->CurrentBar <= ComposerState->BarCreationThreshold)
 		{
 			float StrategyAppropriateness = 0.0f;
 			IMusicStrategy* ChosenStrategy = ChooseMusicalStrategy(ComposerData, StrategyAppropriateness);
@@ -189,8 +203,8 @@ void AMusicComposer::CheckAndGenerateBars()
 				return;
 			
 			//TODO Times to Repeat magic number
-			FInstrumentSchedule NewSchedule = GenerateBars(ComposerData, ChosenStrategy, BarsDefined + 1, 2);
-			ComposerState->ComposerDataObjects[i].ScheduleData.Emplace(NewSchedule);
+			const FInstrumentSchedule NewSchedule = GenerateBars(ComposerData, ChosenStrategy, BarsDefined + 1, 2);
+			ComposerState->ComposerDataObjects[i].EmplaceScheduleData(NewSchedule);
 		}
 	}
 }

--- a/Source/LETSGO/MusicEngine/MusicComposition/MusicComposer.cpp
+++ b/Source/LETSGO/MusicEngine/MusicComposition/MusicComposer.cpp
@@ -178,7 +178,7 @@ void AMusicComposer::CheckAndGenerateBars(const int32 NumBars)
 		if (BarsDefined - NumBars < ComposerState->BarCreationThreshold)
 		{
 			//TODO Times to Repeat magic number
-			FInstrumentScheduleData NewSchedule = GenerateBars(ComposerData, NumBars + 1, 2);
+			FInstrumentScheduleData NewSchedule = GenerateBars(ComposerData, BarsDefined + 1, 2);
 
 			if (NewSchedule.IsValid)
 			{

--- a/Source/LETSGO/MusicEngine/MusicComposition/MusicComposer.cpp
+++ b/Source/LETSGO/MusicEngine/MusicComposition/MusicComposer.cpp
@@ -34,7 +34,8 @@ void AMusicComposer::Initialize()
 {
 	const UWorld* World = GetWorld();
 	ALetsGoGameMode* GameMode = Cast<ALetsGoGameMode>(World->GetAuthGameMode());
-	GameMode->OnMusicalStateUpdated.AddDynamic(this, &AMusicComposer::GenerateScale);
+	GameMode->OnTonicSet.AddDynamic(this, &AMusicComposer::GenerateScale);
+	GameMode->OnIntervalSet.AddUniqueDynamic(this, &AMusicComposer::UpdateAllowableNoteIndices);
 
 	const AClockSettings* ClockSettings = GameMode->GetClockSettings();
 	UQuartzClockHandle* MainClock = ClockSettings->MainClock;
@@ -50,8 +51,6 @@ void AMusicComposer::Initialize()
 
 void AMusicComposer::InitializeComposerData()
 {
-	ALetsGoGameMode* GameMode = Cast<ALetsGoGameMode>(GetWorld()->GetAuthGameMode());
-	// ADrumSoundCueMapping* SoundCueMapping =  GameMode->GetInstrumentData_Drums();
 	
 	/*
 	FComposerData Snare = FComposerData(EInstrumentRoles::Snare,SoundCueMapping->GetInstrumentData(EInstrumentRoles::Snare));

--- a/Source/LETSGO/MusicEngine/MusicComposition/MusicComposer.cpp
+++ b/Source/LETSGO/MusicEngine/MusicComposition/MusicComposer.cpp
@@ -169,7 +169,7 @@ void AMusicComposer::CheckAndGenerateBars(const int32 CurrentBar)
 			float StrategyAppropriateness = 0.0f;
 			IMusicStrategy* ChosenStrategy = ChooseMusicalStrategy(ComposerData, StrategyAppropriateness);
 
-			if (StrategyAppropriateness == 0)
+			if (StrategyAppropriateness < ComposerState->MusicalStrategyAppropriatenessThreshold)
 				return;
 			
 			//TODO Times to Repeat magic number

--- a/Source/LETSGO/MusicEngine/MusicComposition/MusicComposer.cpp
+++ b/Source/LETSGO/MusicEngine/MusicComposition/MusicComposer.cpp
@@ -107,12 +107,14 @@ void AMusicComposer::InitializeStrategies()
 
 FInstrumentScheduleData AMusicComposer::GenerateBars(FComposerData ComposerData, const int StartAtBar, const int TimesToRepeat)
 {
-	FMusicStrategyData ChosenStrategy = MusicalStrategies[0]; 
+	FMusicStrategyData ChosenStrategy = MusicalStrategies[0];
+	TSharedPtr<FComposerData> ComposerDataPtr = MakeShared<FComposerData>();
+	// FComposerData* ComposerDataPtr = ComposerData;
 	for(int i = 0; i < MusicalStrategies.Num(); i++)
 	{
 		FMusicStrategyData CandidateStrategy = MusicalStrategies[i];
 		const float Appropriateness = CandidateStrategy.Strategy->GetStrategyAppropriateness(
-					ComposerData, ComposerState);
+					ComposerDataPtr, ComposerState);
 		if ( Appropriateness > ChosenStrategy.StrategyAppropriateness)
 		{
 			CandidateStrategy.StrategyAppropriateness = Appropriateness;
@@ -129,7 +131,7 @@ FInstrumentScheduleData AMusicComposer::GenerateBars(FComposerData ComposerData,
 
 	FInstrumentScheduleData ScheduleData = FInstrumentScheduleData( FInstrumentSchedule(), StartAtBar, TimesToRepeat);
 
-	FInstrumentSchedule InstrumentSchedule = ChosenStrategy.Strategy->Apply(ComposerData, ScheduleData);
+	FInstrumentSchedule InstrumentSchedule = ChosenStrategy.Strategy->Apply(ComposerDataPtr, ScheduleData);
 
 	ScheduleData.InstrumentSchedule = InstrumentSchedule;
 	ScheduleData.StrategyData = ChosenStrategy;

--- a/Source/LETSGO/MusicEngine/MusicComposition/MusicComposer.h
+++ b/Source/LETSGO/MusicEngine/MusicComposition/MusicComposer.h
@@ -6,11 +6,7 @@
 #include "ComposerData.h"
 #include "MusicComposerState.h"
 #include "GameFramework/Actor.h"
-#include "LETSGO/Instruments/Drum/DrumSoundCueMapping.h"
-#include "LETSGO/MusicEngine/ULetsGoMusicEngine.h"
 #include "MusicComposer.generated.h"
-
-
 
 UCLASS()
 class LETSGO_API AMusicComposer : public AActor
@@ -25,10 +21,7 @@ public:
 	AMusicComposerState* ComposerState;
 
 	UPROPERTY(BlueprintReadWrite, EditDefaultsOnly, Category="LETSGO")
-	TSubclassOf<AMusicComposerState> ComposerStateClass; 
-
-	UPROPERTY()
-	TArray<FComposerData> ComposerDataObjects;
+	TSubclassOf<AMusicComposerState> ComposerStateClass;
 
 	UPROPERTY()
 	TArray<FMusicStrategyData> MusicalStrategies;
@@ -63,6 +56,11 @@ public:
 
 	UFUNCTION()
 	void GenerateScale();
+
+	UFUNCTION()
+	void UpdateAllowableNoteIndices(int Interval);
+
+	UFUNCTION()
 	void CheckAndGenerateBars(int32 NumBars);
 
 	UFUNCTION()

--- a/Source/LETSGO/MusicEngine/MusicComposition/MusicComposer.h
+++ b/Source/LETSGO/MusicEngine/MusicComposition/MusicComposer.h
@@ -24,7 +24,7 @@ public:
 	TSubclassOf<AMusicComposerState> ComposerStateClass;
 
 	UPROPERTY()
-	TArray<FMusicStrategyData> MusicalStrategies;
+	TArray<IMusicStrategy*> MusicalStrategies;
 	
 	UPROPERTY()
 	FOnQuartzMetronomeEventBP OnBeatQuantizationDelegate;
@@ -50,9 +50,10 @@ public:
 	
 	UFUNCTION()
 	void InitializeStrategies();
-
-	UFUNCTION()
-	FInstrumentScheduleData GenerateBars(FComposerData ComposerData, int StartAtBar, int TimesToRepeat);
+	
+	IMusicStrategy* ChooseMusicalStrategy(const TSharedPtr<FComposerData>& ComposerDataPtr, float& AppropriatenessOut);
+	
+	FInstrumentSchedule GenerateBars(TSharedPtr<FComposerData>& ComposerData, IMusicStrategy* ChosenStrategy, int StartAtBar, int TimesToRepeat);
 
 	UFUNCTION()
 	void GenerateScale();
@@ -61,7 +62,7 @@ public:
 	void UpdateAllowableNoteIndices(int Interval);
 
 	UFUNCTION()
-	void CheckAndGenerateBars(int32 NumBars);
+	void CheckAndGenerateBars(int32 CurrentBar);
 
 	UFUNCTION()
 	void OnQuantizationBoundaryTriggered(FName ClockName, EQuartzCommandQuantization QuantizationType, int32 NumBars, int32 Beat, float BeatFraction);

--- a/Source/LETSGO/MusicEngine/MusicComposition/MusicComposer.h
+++ b/Source/LETSGO/MusicEngine/MusicComposition/MusicComposer.h
@@ -59,7 +59,7 @@ public:
 	UFUNCTION()
 	void InitializeStrategies();
 	
-	IMusicStrategy* ChooseMusicalStrategy(const FComposerData& ComposerDataPtr, float& AppropriatenessOut);
+	IMusicStrategy* ChooseMusicalStrategy(const FComposerData& ComposerData, float& AppropriatenessOut);
 	
 	FInstrumentSchedule GenerateBars(FComposerData& ComposerData, IMusicStrategy* ChosenStrategy, int StartAtBar, int TimesToRepeat);
 

--- a/Source/LETSGO/MusicEngine/MusicComposition/MusicComposer.h
+++ b/Source/LETSGO/MusicEngine/MusicComposition/MusicComposer.h
@@ -7,6 +7,7 @@
 #include "MusicComposerState.h"
 #include "MusicStrategy.h"
 #include "GameFramework/Actor.h"
+#include "LETSGO/Instruments/Instrument.h"
 #include "MusicComposer.generated.h"
 
 UCLASS()
@@ -15,7 +16,6 @@ class LETSGO_API AMusicComposer : public AActor
 	GENERATED_BODY()
 
 public:
-	// Sets default values for this actor's properties
 	AMusicComposer();
 
 	UPROPERTY()
@@ -33,9 +33,6 @@ public:
 	UPROPERTY(BlueprintReadWrite, EditDefaultsOnly, Category="LETSGO")
 	TSubclassOf<AInstrument> InstrumentClass;
 
-	/*UPROPERTY()
-	UQuartzClockHandle* Clock;*/
-	
 protected:
 	// Called when the game starts or when spawned
 	virtual void BeginPlay() override;
@@ -61,20 +58,12 @@ public:
 	
 	IMusicStrategy* ChooseMusicalStrategy(const FComposerData& ComposerData, float& AppropriatenessOut);
 	
-	FInstrumentSchedule GenerateBars(FComposerData& ComposerData, IMusicStrategy* ChosenStrategy, int StartAtBar, int TimesToRepeat);
-
 	UFUNCTION()
 	void GenerateScale();
 
 	UFUNCTION()
 	void UpdateAllowableNoteIndices(int Interval);
 
-	UFUNCTION()
-	void CheckAndGenerateBars();
-
-	/*
-	UFUNCTION()
-	void OnQuantizationBoundaryTriggered(FName ClockName, EQuartzCommandQuantization QuantizationType, int32 NumBars, int32 Beat, float BeatFraction);
-	*/
+	// FInstrumentSchedule GenerateBars(FComposerData Data);
 
 };

--- a/Source/LETSGO/MusicEngine/MusicComposition/MusicComposer.h
+++ b/Source/LETSGO/MusicEngine/MusicComposition/MusicComposer.h
@@ -4,6 +4,7 @@
 
 #include "CoreMinimal.h"
 #include "ComposerData.h"
+#include "MusicComposerState.h"
 #include "GameFramework/Actor.h"
 #include "LETSGO/Instruments/Drum/DrumSoundCueMapping.h"
 #include "LETSGO/MusicEngine/ULetsGoMusicEngine.h"
@@ -21,10 +22,10 @@ public:
 	AMusicComposer();
 
 	UPROPERTY()
-	int32 BarCreationThreshold = 4;
-	
-	UPROPERTY()
-	FLetsGoGeneratedScale Scale; 
+	AMusicComposerState* ComposerState;
+
+	UPROPERTY(BlueprintReadWrite, EditDefaultsOnly, Category="LETSGO")
+	TSubclassOf<AMusicComposerState> ComposerStateClass; 
 
 	UPROPERTY()
 	TArray<FComposerData> ComposerDataObjects;

--- a/Source/LETSGO/MusicEngine/MusicComposition/MusicComposer.h
+++ b/Source/LETSGO/MusicEngine/MusicComposition/MusicComposer.h
@@ -5,6 +5,7 @@
 #include "CoreMinimal.h"
 #include "ComposerData.h"
 #include "MusicComposerState.h"
+#include "MusicStrategy.h"
 #include "GameFramework/Actor.h"
 #include "MusicComposer.generated.h"
 
@@ -32,9 +33,14 @@ public:
 	UPROPERTY(BlueprintReadWrite, EditDefaultsOnly, Category="LETSGO")
 	TSubclassOf<AInstrument> InstrumentClass;
 
+	UPROPERTY()
+	UQuartzClockHandle* Clock;
+	
 protected:
 	// Called when the game starts or when spawned
 	virtual void BeginPlay() override;
+
+	virtual void BeginDestroy() override;
 
 	bool Started = false;
 

--- a/Source/LETSGO/MusicEngine/MusicComposition/MusicComposer.h
+++ b/Source/LETSGO/MusicEngine/MusicComposition/MusicComposer.h
@@ -33,8 +33,8 @@ public:
 	UPROPERTY(BlueprintReadWrite, EditDefaultsOnly, Category="LETSGO")
 	TSubclassOf<AInstrument> InstrumentClass;
 
-	UPROPERTY()
-	UQuartzClockHandle* Clock;
+	/*UPROPERTY()
+	UQuartzClockHandle* Clock;*/
 	
 protected:
 	// Called when the game starts or when spawned
@@ -43,6 +43,8 @@ protected:
 	virtual void BeginDestroy() override;
 
 	bool Started = false;
+
+	int LastProcessedBar = 0;
 
 public:
 	// Called every frame
@@ -68,8 +70,11 @@ public:
 	void UpdateAllowableNoteIndices(int Interval);
 
 	UFUNCTION()
-	void CheckAndGenerateBars(int32 CurrentBar);
+	void CheckAndGenerateBars();
 
+	/*
 	UFUNCTION()
 	void OnQuantizationBoundaryTriggered(FName ClockName, EQuartzCommandQuantization QuantizationType, int32 NumBars, int32 Beat, float BeatFraction);
+	*/
+
 };

--- a/Source/LETSGO/MusicEngine/MusicComposition/MusicComposer.h
+++ b/Source/LETSGO/MusicEngine/MusicComposition/MusicComposer.h
@@ -57,9 +57,9 @@ public:
 	UFUNCTION()
 	void InitializeStrategies();
 	
-	IMusicStrategy* ChooseMusicalStrategy(const TSharedPtr<FComposerData>& ComposerDataPtr, float& AppropriatenessOut);
+	IMusicStrategy* ChooseMusicalStrategy(const FComposerData& ComposerDataPtr, float& AppropriatenessOut);
 	
-	FInstrumentSchedule GenerateBars(TSharedPtr<FComposerData>& ComposerData, IMusicStrategy* ChosenStrategy, int StartAtBar, int TimesToRepeat);
+	FInstrumentSchedule GenerateBars(FComposerData& ComposerData, IMusicStrategy* ChosenStrategy, int StartAtBar, int TimesToRepeat);
 
 	UFUNCTION()
 	void GenerateScale();

--- a/Source/LETSGO/MusicEngine/MusicComposition/MusicComposerState.cpp
+++ b/Source/LETSGO/MusicEngine/MusicComposition/MusicComposerState.cpp
@@ -1,0 +1,41 @@
+﻿// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "MusicComposerState.h"
+
+#include "LETSGO/GameModes/ALetsGoGameMode.h"
+
+
+// Sets default values
+AMusicComposerState::AMusicComposerState()
+{
+	// Set this actor to call Tick() every frame.  You can turn this off to improve performance if you don't need it.
+	PrimaryActorTick.bCanEverTick = true;
+
+	CheeseKeySoundCueMapping = CreateDefaultSubobject<ACheeseKeySoundCueMapping>(TEXT("Cheese"));
+	DrumsSoundCueMapping = CreateDefaultSubobject<ADrumSoundCueMapping>(TEXT("Drums"));
+
+}
+
+// Called when the game starts or when spawned
+void AMusicComposerState::BeginPlay()
+{
+	Super::BeginPlay();
+	
+}
+
+// Called every frame
+void AMusicComposerState::Tick(float DeltaTime)
+{
+	Super::Tick(DeltaTime);
+}
+
+void AMusicComposerState::Initialize(const FLetsGoGeneratedScale& InScale)
+{
+	Scale = InScale;
+	ALetsGoGameMode* GameMode = Cast<ALetsGoGameMode>(GetWorld()->GetAuthGameMode());
+	CheeseKeySoundCueMapping = GameMode->GetInstrumentData_CheeseKey();
+	DrumsSoundCueMapping = GameMode->GetInstrumentData_Drums();
+	
+}
+

--- a/Source/LETSGO/MusicEngine/MusicComposition/MusicComposerState.cpp
+++ b/Source/LETSGO/MusicEngine/MusicComposition/MusicComposerState.cpp
@@ -30,9 +30,11 @@ void AMusicComposerState::Tick(float DeltaTime)
 	Super::Tick(DeltaTime);
 }
 
-void AMusicComposerState::Initialize(const FLetsGoGeneratedScale& InScale)
+void AMusicComposerState::Initialize()
 {
-	Scale = InScale;
+	Scale = ULetsGoMusicEngine::GenerateScale(ULetsGoMusicEngine::Chromatic, FLetsGoMusicNotes(C));
+	AllowableNoteIndices = TArray<int>();
+	
 	ALetsGoGameMode* GameMode = Cast<ALetsGoGameMode>(GetWorld()->GetAuthGameMode());
 	CheeseKeySoundCueMapping = GameMode->GetInstrumentData_CheeseKey();
 	DrumsSoundCueMapping = GameMode->GetInstrumentData_Drums();

--- a/Source/LETSGO/MusicEngine/MusicComposition/MusicComposerState.cpp
+++ b/Source/LETSGO/MusicEngine/MusicComposition/MusicComposerState.cpp
@@ -24,6 +24,13 @@ void AMusicComposerState::BeginPlay()
 	
 }
 
+void AMusicComposerState::BeginDestroy()
+{
+	
+	Super::BeginDestroy();
+
+}
+
 // Called every frame
 void AMusicComposerState::Tick(float DeltaTime)
 {

--- a/Source/LETSGO/MusicEngine/MusicComposition/MusicComposerState.cpp
+++ b/Source/LETSGO/MusicEngine/MusicComposition/MusicComposerState.cpp
@@ -45,6 +45,7 @@ void AMusicComposerState::Initialize()
 	ALetsGoGameMode* GameMode = Cast<ALetsGoGameMode>(GetWorld()->GetAuthGameMode());
 	CheeseKeySoundCueMapping = GameMode->GetInstrumentData_CheeseKey();
 	DrumsSoundCueMapping = GameMode->GetInstrumentData_Drums();
-	
+
+	ComposerDataObjects = MakeShared<TArray<FComposerData>>();
 }
 

--- a/Source/LETSGO/MusicEngine/MusicComposition/MusicComposerState.h
+++ b/Source/LETSGO/MusicEngine/MusicComposition/MusicComposerState.h
@@ -20,6 +20,9 @@ public:
 	
 	UPROPERTY(BlueprintReadWrite, EditDefaultsOnly)
 	int32 BarCreationThreshold = 4;
+
+	UPROPERTY(BlueprintReadWrite, EditDefaultsOnly)
+	float MusicalStrategyAppropriatenessThreshold = 0.5f;
 	
 	UPROPERTY()
 	FLetsGoGeneratedScale Scale;

--- a/Source/LETSGO/MusicEngine/MusicComposition/MusicComposerState.h
+++ b/Source/LETSGO/MusicEngine/MusicComposition/MusicComposerState.h
@@ -19,7 +19,7 @@ public:
 	AMusicComposerState();
 	
 	UPROPERTY(BlueprintReadWrite, EditDefaultsOnly)
-	int32 BarCreationThreshold = 4;
+	int32 BarCreationThreshold = 8;
 
 	UPROPERTY(BlueprintReadWrite, EditDefaultsOnly)
 	float MusicalStrategyAppropriatenessThreshold = 0.5f;
@@ -33,8 +33,7 @@ public:
 	UPROPERTY()
 	TArray<int> AllowableNoteIndices;
 
-	UPROPERTY()
-	TArray<FComposerData> ComposerDataObjects;
+	TSharedPtr<TArray<FComposerData>> ComposerDataObjects;
 
 	UPROPERTY()
 	ACheeseKeySoundCueMapping* CheeseKeySoundCueMapping;

--- a/Source/LETSGO/MusicEngine/MusicComposition/MusicComposerState.h
+++ b/Source/LETSGO/MusicEngine/MusicComposition/MusicComposerState.h
@@ -41,10 +41,15 @@ public:
 
 	UPROPERTY()
 	ADrumSoundCueMapping* DrumsSoundCueMapping;
+
+	UPROPERTY()
+	int CurrentBar;
 	
 protected:
 	// Called when the game starts or when spawned
 	virtual void BeginPlay() override;
+
+	virtual void BeginDestroy() override;
 
 public:
 	// Called every frame

--- a/Source/LETSGO/MusicEngine/MusicComposition/MusicComposerState.h
+++ b/Source/LETSGO/MusicEngine/MusicComposition/MusicComposerState.h
@@ -25,6 +25,9 @@ public:
 	FLetsGoGeneratedScale Scale;
 
 	UPROPERTY()
+	bool IsTonicSet = false;
+
+	UPROPERTY()
 	TArray<int> AllowableNoteIndices;
 
 	UPROPERTY()

--- a/Source/LETSGO/MusicEngine/MusicComposition/MusicComposerState.h
+++ b/Source/LETSGO/MusicEngine/MusicComposition/MusicComposerState.h
@@ -1,0 +1,42 @@
+﻿// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/Actor.h"
+#include "LETSGO/Instruments/Cheese Keys/CheeseKeySoundCueMapping.h"
+#include "LETSGO/Instruments/Drum/DrumSoundCueMapping.h"
+#include "LETSGO/MusicEngine/ULetsGoMusicEngine.h"
+#include "MusicComposerState.generated.h"
+
+UCLASS()
+class LETSGO_API AMusicComposerState : public AActor
+{
+	GENERATED_BODY()
+
+public:
+	// Sets default values for this actor's properties
+	AMusicComposerState();
+	
+	UPROPERTY(BlueprintReadWrite, EditDefaultsOnly)
+	int32 BarCreationThreshold = 4;
+	
+	UPROPERTY()
+	FLetsGoGeneratedScale Scale;
+
+	UPROPERTY()
+	ACheeseKeySoundCueMapping* CheeseKeySoundCueMapping;
+
+	UPROPERTY()
+	ADrumSoundCueMapping* DrumsSoundCueMapping;
+	
+protected:
+	// Called when the game starts or when spawned
+	virtual void BeginPlay() override;
+
+public:
+	// Called every frame
+	virtual void Tick(float DeltaTime) override;
+
+	void Initialize(const FLetsGoGeneratedScale& Scale);
+};

--- a/Source/LETSGO/MusicEngine/MusicComposition/MusicComposerState.h
+++ b/Source/LETSGO/MusicEngine/MusicComposition/MusicComposerState.h
@@ -25,6 +25,12 @@ public:
 	FLetsGoGeneratedScale Scale;
 
 	UPROPERTY()
+	TArray<int> AllowableNoteIndices;
+
+	UPROPERTY()
+	TArray<FComposerData> ComposerDataObjects;
+
+	UPROPERTY()
 	ACheeseKeySoundCueMapping* CheeseKeySoundCueMapping;
 
 	UPROPERTY()
@@ -38,5 +44,5 @@ public:
 	// Called every frame
 	virtual void Tick(float DeltaTime) override;
 
-	void Initialize(const FLetsGoGeneratedScale& Scale);
+	void Initialize();
 };

--- a/Source/LETSGO/MusicEngine/MusicComposition/MusicConductor.cpp
+++ b/Source/LETSGO/MusicEngine/MusicComposition/MusicConductor.cpp
@@ -85,15 +85,9 @@ void AMusicConductor::OnQuantizationBoundaryTriggered(FName ClockName, EQuartzCo
 {
 	ComposerState->CurrentBar = NumBars;
 
-	for (int i = 0; i < ComposerState->ComposerDataObjects->Num(); i++)
-	{
-		TArray<FComposerData> Datas = (*ComposerState->ComposerDataObjects);
-		int Test = Datas[i].ScheduleData->Num();
-		if(GEngine)
-			GEngine->AddOnScreenDebugMessage(-1, 15.0f, FColor::Magenta, FString::Printf(TEXT("Number of SchedulesDatas in Conductor: [%i]"), Test));
-	}
-	
+	/*
 	if(GEngine)
 		GEngine->AddOnScreenDebugMessage(-1, 15.0f, FColor::Yellow, FString::Printf(TEXT("Current Bar [%i]"), NumBars));
+	*/
 }
 

--- a/Source/LETSGO/MusicEngine/MusicComposition/MusicConductor.cpp
+++ b/Source/LETSGO/MusicEngine/MusicComposition/MusicConductor.cpp
@@ -64,7 +64,8 @@ void AMusicConductor::Initialize()
 	for(int i = 0; i < ComposerState->ComposerDataObjects.Num(); i++)
 	{
 		AInstrument* Instrument = GetWorld()->SpawnActor<AInstrument>();
-		Instrument->InitializeMultipleSchedules(ComposerState->ComposerDataObjects[i].ScheduleData);
+		TSharedPtr<TArray<FInstrumentSchedule>> Ptr = MakeShared<TArray<FInstrumentSchedule>>(ComposerState->ComposerDataObjects[i].ScheduleData);
+		Instrument->InitializeMultipleSchedules(Ptr);
 		
 		ConductorDatas.Emplace(
 			MakeShared<FComposerData>(ComposerState->ComposerDataObjects[i]),

--- a/Source/LETSGO/MusicEngine/MusicComposition/MusicConductor.cpp
+++ b/Source/LETSGO/MusicEngine/MusicComposition/MusicConductor.cpp
@@ -3,12 +3,16 @@
 
 #include "MusicConductor.h"
 
+#include "LETSGO/GameModes/ALetsGoGameMode.h"
+
 
 // Sets default values
 AMusicConductor::AMusicConductor()
 {
 	// Set this actor to call Tick() every frame.  You can turn this off to improve performance if you don't need it.
 	PrimaryActorTick.bCanEverTick = true;
+
+	QuantizationDelegate.BindUFunction(this, "OnQuantizationBoundaryTriggered");
 }
 
 // Called when the game starts or when spawned
@@ -18,9 +22,61 @@ void AMusicConductor::BeginPlay()
 	
 }
 
+void AMusicConductor::BeginDestroy()
+{
+	if (ConductorDatas.Num() > 0)
+		ConductorDatas.Empty();
+
+	
+	Super::BeginDestroy();
+}
+
+void AMusicConductor::SetClock()
+{
+	// Build Clock Name
+	FString Name = GetName();
+	Name = Name.Append("_Clock");
+	
+	// Get Main Clock
+	const ALetsGoGameMode* GameMode = Cast<ALetsGoGameMode>(GetWorld()->GetAuthGameMode());
+	const AClockSettings* ClockSettings = GameMode->GetClockSettings();
+
+	Clock = ClockSettings->GetNewClock(FName(Name));
+}
+
 // Called every frame
 void AMusicConductor::Tick(float DeltaTime)
 {
 	Super::Tick(DeltaTime);
+}
+
+void AMusicConductor::Initialize()
+{
+	const UWorld* World = GetWorld();
+	SetClock();
+	Clock->StartClock(World, Clock);
+	Clock->SubscribeToQuantizationEvent(GetWorld(), EQuartzCommandQuantization::Bar, QuantizationDelegate, Clock);
+
+	ALetsGoGameMode* GameMode = Cast<ALetsGoGameMode>(World->GetAuthGameMode());
+	const AMusicComposer* Composer = GameMode->GetMusicComposer();
+	ComposerState = Composer->ComposerState;
+	
+	for(int i = 0; i < ComposerState->ComposerDataObjects.Num(); i++)
+	{
+		AInstrument* Instrument = GetWorld()->SpawnActor<AInstrument>();
+		Instrument->InitializeMultipleSchedules(ComposerState->ComposerDataObjects[i].ScheduleData);
+		
+		ConductorDatas.Emplace(
+			MakeShared<FComposerData>(ComposerState->ComposerDataObjects[i]),
+			Instrument
+		);
+		Instrument->Initialize(false, ComposerState->CurrentBar);
+	}
+}
+
+void AMusicConductor::OnQuantizationBoundaryTriggered(FName ClockName, EQuartzCommandQuantization QuantizationType,
+                                                      int32 NumBars, int32 Beat, float BeatFraction)
+{
+	ComposerState->CurrentBar = NumBars;
 }
 

--- a/Source/LETSGO/MusicEngine/MusicComposition/MusicConductor.h
+++ b/Source/LETSGO/MusicEngine/MusicComposition/MusicConductor.h
@@ -3,8 +3,20 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "MusicComposerState.h"
 #include "GameFramework/Actor.h"
 #include "MusicConductor.generated.h"
+
+USTRUCT()
+struct FMusicConductorData
+{
+	GENERATED_BODY()
+
+	TSharedPtr<FComposerData> ComposerData;
+
+	UPROPERTY()
+	AInstrument* Instrument;
+};
 
 UCLASS()
 class LETSGO_API AMusicConductor : public AActor
@@ -15,11 +27,31 @@ public:
 	// Sets default values for this actor's properties
 	AMusicConductor();
 
+	UPROPERTY()
+	AMusicComposerState* ComposerState;
+
+	UPROPERTY()
+	TArray<FMusicConductorData> ConductorDatas;
+
+	UPROPERTY()
+	UQuartzClockHandle* Clock;
+
+	UPROPERTY()
+	FOnQuartzMetronomeEventBP QuantizationDelegate;
+	
 protected:
 	// Called when the game starts or when spawned
 	virtual void BeginPlay() override;
+	virtual void BeginDestroy() override;
+	void SetClock();
 
 public:
 	// Called every frame
 	virtual void Tick(float DeltaTime) override;
+
+	UFUNCTION()
+	void Initialize();
+	
+	UFUNCTION()
+	void OnQuantizationBoundaryTriggered(FName ClockName, EQuartzCommandQuantization QuantizationType, int32 NumBars, int32 Beat, float BeatFraction);
 };

--- a/Source/LETSGO/MusicEngine/MusicComposition/MusicConductor.h
+++ b/Source/LETSGO/MusicEngine/MusicComposition/MusicConductor.h
@@ -5,6 +5,7 @@
 #include "CoreMinimal.h"
 #include "MusicComposerState.h"
 #include "GameFramework/Actor.h"
+#include "LETSGO/Instruments/Instrument.h"
 #include "MusicConductor.generated.h"
 
 USTRUCT()
@@ -12,7 +13,9 @@ struct FMusicConductorData
 {
 	GENERATED_BODY()
 
-	TSharedPtr<FComposerData> ComposerData;
+	UPROPERTY()
+	int ComposerDataIndex;
+	//TSharedPtr<FComposerData> ComposerData;
 
 	UPROPERTY()
 	AInstrument* Instrument;
@@ -38,6 +41,9 @@ public:
 
 	UPROPERTY()
 	FOnQuartzMetronomeEventBP QuantizationDelegate;
+
+	UPROPERTY(BlueprintReadWrite, EditDefaultsOnly, Category="LETSGO")
+	TSubclassOf<AInstrument> InstrumentClass;
 	
 protected:
 	// Called when the game starts or when spawned

--- a/Source/LETSGO/MusicEngine/MusicComposition/MusicStrategy.h
+++ b/Source/LETSGO/MusicEngine/MusicComposition/MusicStrategy.h
@@ -28,9 +28,9 @@ class LETSGO_API IMusicStrategy
 
 	// Add interface functions to this class. This is the class that will be inherited to implement this interface.
 public:
-	virtual FInstrumentSchedule Apply(FComposerData& ComposerData, FInstrumentScheduleData InstrumentScheduleData) = 0;
+	virtual FInstrumentSchedule Apply(TSharedPtr<FComposerData> CurrentComposerData, FInstrumentScheduleData InstrumentScheduleData) = 0;
 
-	virtual float GetStrategyAppropriateness(FComposerData CurrentComposerData, const AMusicComposerState* State) = 0;
+	virtual float GetStrategyAppropriateness(TSharedPtr<FComposerData> CurrentComposerData, const AMusicComposerState* State) = 0;
 
-	virtual float GetInstrumentAppropriateness(FComposerData CurrentComposerData, const AMusicComposerState* State) = 0;
+	virtual float GetInstrumentAppropriateness(TSharedPtr<FComposerData> CurrentComposerData, const AMusicComposerState* State) = 0;
 };

--- a/Source/LETSGO/MusicEngine/MusicComposition/MusicStrategy.h
+++ b/Source/LETSGO/MusicEngine/MusicComposition/MusicStrategy.h
@@ -28,7 +28,7 @@ class LETSGO_API IMusicStrategy
 
 	// Add interface functions to this class. This is the class that will be inherited to implement this interface.
 public:
-	virtual FInstrumentSchedule Apply(TSharedPtr<FComposerData> CurrentComposerData, FInstrumentScheduleData InstrumentScheduleData) = 0;
+	virtual FPerBarSchedule GenerateBar(TSharedPtr<FComposerData> CurrentComposerData, const AMusicComposerState* State) = 0;
 
 	virtual float GetStrategyAppropriateness(TSharedPtr<FComposerData> CurrentComposerData, const AMusicComposerState* State) = 0;
 

--- a/Source/LETSGO/MusicEngine/MusicComposition/MusicStrategy.h
+++ b/Source/LETSGO/MusicEngine/MusicComposition/MusicStrategy.h
@@ -7,6 +7,7 @@
 #include "UObject/Interface.h"
 #include "MusicStrategy.generated.h"
 
+class AMusicComposerState;
 struct FInstrumentScheduleData;
 struct FLetsGoGeneratedScale;
 struct FComposerData;
@@ -29,7 +30,7 @@ class LETSGO_API IMusicStrategy
 public:
 	virtual FInstrumentSchedule Apply(FComposerData& ComposerData, FInstrumentScheduleData InstrumentScheduleData) = 0;
 
-	virtual float GetStrategyAppropriateness(FComposerData CurrentComposerData, TArray<FComposerData> ComposerDataSet, FLetsGoGeneratedScale Scale) = 0;
+	virtual float GetStrategyAppropriateness(FComposerData CurrentComposerData, const AMusicComposerState* State) = 0;
 
-	virtual float GetInstrumentAppropriateness(FComposerData CurrentComposerData, TArray<FComposerData> ComposerDataSet) = 0;
+	virtual float GetInstrumentAppropriateness(FComposerData CurrentComposerData, const AMusicComposerState* State) = 0;
 };

--- a/Source/LETSGO/MusicEngine/MusicComposition/MusicStrategy.h
+++ b/Source/LETSGO/MusicEngine/MusicComposition/MusicStrategy.h
@@ -28,9 +28,9 @@ class LETSGO_API IMusicStrategy
 
 	// Add interface functions to this class. This is the class that will be inherited to implement this interface.
 public:
-	virtual FPerBarSchedule GenerateBar(TSharedPtr<FComposerData> CurrentComposerData, const AMusicComposerState* State) = 0;
+	virtual FPerBarSchedule GenerateBar(const FComposerData& CurrentComposerData, const AMusicComposerState* State) = 0;
 
-	virtual float GetStrategyAppropriateness(TSharedPtr<FComposerData> CurrentComposerData, const AMusicComposerState* State) = 0;
+	virtual float GetStrategyAppropriateness(const FComposerData& CurrentComposerData, const AMusicComposerState* State) = 0;
 
-	virtual float GetInstrumentAppropriateness(TSharedPtr<FComposerData> CurrentComposerData, const AMusicComposerState* State) = 0;
+	virtual float GetInstrumentAppropriateness(const FComposerData& CurrentComposerData, const AMusicComposerState* State) = 0;
 };

--- a/Source/LETSGO/MusicEngine/MusicComposition/Strategy_PedalPointComposition.cpp
+++ b/Source/LETSGO/MusicEngine/MusicComposition/Strategy_PedalPointComposition.cpp
@@ -7,11 +7,11 @@
 #include "MusicComposerState.h"
 #include "LETSGO/Instruments/InstrumentSchedule.h"
 
-FPerBarSchedule UStrategy_PedalPointComposition::GenerateBar(TSharedPtr<FComposerData> CurrentComposerData, const AMusicComposerState* State)
+FPerBarSchedule UStrategy_PedalPointComposition::GenerateBar(const FComposerData& CurrentComposerData, const AMusicComposerState* State)
 {
 	// Filter the array
-	TArray<FInstrumentNote> FilteredNotes = CurrentComposerData->InstrumentData.Notes.FilterByPredicate([&] (const FInstrumentNote& InstrumentNote){
-		return InstrumentNote.Octave == CurrentComposerData->OctaveMin && InstrumentNote.Note == State->Scale.Tonic.Note;
+	TArray<FInstrumentNote> FilteredNotes = CurrentComposerData.InstrumentData.Notes.FilterByPredicate([&] (const FInstrumentNote& InstrumentNote){
+		return InstrumentNote.Octave == CurrentComposerData.OctaveMin && InstrumentNote.Note == State->Scale.Tonic.Note;
 	});
 	
 	FPerBarSchedule Bar =  FPerBarSchedule({
@@ -24,21 +24,21 @@ FPerBarSchedule UStrategy_PedalPointComposition::GenerateBar(TSharedPtr<FCompose
 	return Bar;
 }
 
-float UStrategy_PedalPointComposition::GetStrategyAppropriateness(TSharedPtr<FComposerData> CurrentComposerData, const AMusicComposerState* State)
+float UStrategy_PedalPointComposition::GetStrategyAppropriateness(const FComposerData& CurrentComposerData, const AMusicComposerState* State)
 {
-	if (! CurrentComposerData->IsMultiNoteInstrument() || State->AllowableNoteIndices.Num() == 0)
+	if (! CurrentComposerData.IsMultiNoteInstrument() || State->AllowableNoteIndices.Num() == 0)
 	{
 		return 0.0f;
 	}
 
 	float Weight = 0.2f;
 
-	if (CurrentComposerData->InstrumentRole == Bass)
+	if (CurrentComposerData.InstrumentRole == Bass)
 	{
 		Weight += 0.3f;
 	}
 
-	if (CurrentComposerData->ScheduleData.Num() == 0)
+	if (CurrentComposerData.ScheduleData.Num() == 0)
 	{
 		Weight += 0.3;
 	}
@@ -56,7 +56,7 @@ float UStrategy_PedalPointComposition::GetStrategyAppropriateness(TSharedPtr<FCo
 }
 
 // This strategy doesn't need input from other instruments
-float UStrategy_PedalPointComposition::GetInstrumentAppropriateness(TSharedPtr<FComposerData> CurrentComposerData,
+float UStrategy_PedalPointComposition::GetInstrumentAppropriateness(const FComposerData& CurrentComposerData,
 	const AMusicComposerState* State)
 {
 	return 0.0f;

--- a/Source/LETSGO/MusicEngine/MusicComposition/Strategy_PedalPointComposition.cpp
+++ b/Source/LETSGO/MusicEngine/MusicComposition/Strategy_PedalPointComposition.cpp
@@ -7,11 +7,11 @@
 #include "MusicComposerState.h"
 #include "LETSGO/Instruments/InstrumentSchedule.h"
 
-FInstrumentSchedule UStrategy_PedalPointComposition::Apply(FComposerData& ComposerData, FInstrumentScheduleData InstrumentScheduleData)
+FInstrumentSchedule UStrategy_PedalPointComposition::Apply(TSharedPtr<FComposerData> CurrentComposerData, FInstrumentScheduleData InstrumentScheduleData)
 {
 	// Filter the array
-	TArray<FInstrumentNote> FilteredNotes = ComposerData.InstrumentData.Notes.FilterByPredicate([&] (const FInstrumentNote& InstrumentNote){
-		return InstrumentNote.Octave == ComposerData.OctaveMin && InstrumentNote.Note == ComposerData.Scale.Tonic.Note;
+	TArray<FInstrumentNote> FilteredNotes = CurrentComposerData->InstrumentData.Notes.FilterByPredicate([&] (const FInstrumentNote& InstrumentNote){
+		return InstrumentNote.Octave == CurrentComposerData->OctaveMin && InstrumentNote.Note == CurrentComposerData->Scale.Tonic.Note;
 	});
 	
 	FInstrumentSchedule Schedule = FInstrumentSchedule();
@@ -32,9 +32,9 @@ FInstrumentSchedule UStrategy_PedalPointComposition::Apply(FComposerData& Compos
 	return Schedule;
 }
 
-float UStrategy_PedalPointComposition::GetStrategyAppropriateness(FComposerData CurrentComposerData, const AMusicComposerState* State)
+float UStrategy_PedalPointComposition::GetStrategyAppropriateness(TSharedPtr<FComposerData> CurrentComposerData, const AMusicComposerState* State)
 {
-	if (! CurrentComposerData.IsMultiNoteInstrument() || State->AllowableNoteIndices.Num() == 0)
+	if (! CurrentComposerData->IsMultiNoteInstrument() || State->AllowableNoteIndices.Num() == 0)
 	{
 		return 0.0f;
 	}
@@ -57,7 +57,7 @@ float UStrategy_PedalPointComposition::GetStrategyAppropriateness(FComposerData 
 }
 
 // This strategy doesn't need input from other instruments
-float UStrategy_PedalPointComposition::GetInstrumentAppropriateness(FComposerData CurrentComposerData,
+float UStrategy_PedalPointComposition::GetInstrumentAppropriateness(TSharedPtr<FComposerData> CurrentComposerData,
 	const AMusicComposerState* State)
 {
 	return 0.0f;

--- a/Source/LETSGO/MusicEngine/MusicComposition/Strategy_PedalPointComposition.cpp
+++ b/Source/LETSGO/MusicEngine/MusicComposition/Strategy_PedalPointComposition.cpp
@@ -4,8 +4,8 @@
 #include "Strategy_PedalPointComposition.h"
 
 #include "ComposerData.h"
+#include "MusicComposerState.h"
 #include "LETSGO/Instruments/InstrumentSchedule.h"
-#include "LETSGO/Instruments/Cheese Keys/CheeseKeySoundCueMapping.h"
 
 FInstrumentSchedule UStrategy_PedalPointComposition::Apply(FComposerData& ComposerData, FInstrumentScheduleData InstrumentScheduleData)
 {
@@ -32,20 +32,18 @@ FInstrumentSchedule UStrategy_PedalPointComposition::Apply(FComposerData& Compos
 	return Schedule;
 }
 
-float UStrategy_PedalPointComposition::GetStrategyAppropriateness(FComposerData CurrentComposerData, TArray<FComposerData> ComposerDataSet, FLetsGoGeneratedScale Scale)
+float UStrategy_PedalPointComposition::GetStrategyAppropriateness(FComposerData CurrentComposerData, const AMusicComposerState* State)
 {
-	if (Scale.IsValid ||
-		! Scale.Tonic.Note ||
-		! CurrentComposerData.IsMultiNoteInstrument())
+	if (! CurrentComposerData.IsMultiNoteInstrument() || State->AllowableNoteIndices.Num() == 0)
 	{
 		return 0.0f;
 	}
 
 	float Weight = 1.0f;
 
-	for (int i = 0; i < ComposerDataSet.Num(); i++)
+	for (int i = 0; i < State->ComposerDataObjects.Num(); i++)
 	{
-		FComposerData ComposerData = ComposerDataSet[i];
+		FComposerData ComposerData = State->ComposerDataObjects[i];
 		for (int ScheduleDataIndex = 0; ScheduleDataIndex < ComposerData.ScheduleData.Num(); ScheduleDataIndex++)
 		{
 			if (FInstrumentScheduleData ScheduleData = ComposerData.ScheduleData[i]; ScheduleData.StrategyData.StrategyType == CreateMotif)
@@ -60,7 +58,7 @@ float UStrategy_PedalPointComposition::GetStrategyAppropriateness(FComposerData 
 
 // This strategy doesn't need input from other instruments
 float UStrategy_PedalPointComposition::GetInstrumentAppropriateness(FComposerData CurrentComposerData,
-	TArray<FComposerData> ComposerDataSet)
+	const AMusicComposerState* State)
 {
 	return 0.0f;
 }

--- a/Source/LETSGO/MusicEngine/MusicComposition/Strategy_PedalPointComposition.cpp
+++ b/Source/LETSGO/MusicEngine/MusicComposition/Strategy_PedalPointComposition.cpp
@@ -38,7 +38,7 @@ float UStrategy_PedalPointComposition::GetStrategyAppropriateness(const FCompose
 		Weight += 0.3f;
 	}
 
-	if (CurrentComposerData.ScheduleData.Num() == 0)
+	if (CurrentComposerData.ScheduleData->Num() == 0)
 	{
 		Weight += 0.3;
 	}

--- a/Source/LETSGO/MusicEngine/MusicComposition/Strategy_PedalPointComposition.h
+++ b/Source/LETSGO/MusicEngine/MusicComposition/Strategy_PedalPointComposition.h
@@ -17,8 +17,8 @@ class LETSGO_API UStrategy_PedalPointComposition : public UObject, public IMusic
 	GENERATED_BODY()
 
 public:
-	virtual FPerBarSchedule GenerateBar(TSharedPtr<FComposerData> CurrentComposerData, const AMusicComposerState* State) override;
-	virtual float GetStrategyAppropriateness(TSharedPtr<FComposerData> CurrentComposerData, const AMusicComposerState* State) override;
+	virtual FPerBarSchedule GenerateBar(const FComposerData& CurrentComposerData, const AMusicComposerState* State) override;
+	virtual float GetStrategyAppropriateness(const FComposerData& CurrentComposerData, const AMusicComposerState* State) override;
 	virtual float
-	GetInstrumentAppropriateness(TSharedPtr<FComposerData> CurrentComposerData, const AMusicComposerState* State) override;
+	GetInstrumentAppropriateness(const FComposerData& CurrentComposerData, const AMusicComposerState* State) override;
 };

--- a/Source/LETSGO/MusicEngine/MusicComposition/Strategy_PedalPointComposition.h
+++ b/Source/LETSGO/MusicEngine/MusicComposition/Strategy_PedalPointComposition.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "MusicComposerState.h"
 #include "MusicStrategy.h"
 #include "UObject/Object.h"
 #include "Strategy_PedalPointComposition.generated.h"
@@ -17,7 +18,7 @@ class LETSGO_API UStrategy_PedalPointComposition : public UObject, public IMusic
 
 public:
 	virtual FInstrumentSchedule Apply(FComposerData& ComposerData, FInstrumentScheduleData InstrumentScheduleData) override;
-	virtual float GetStrategyAppropriateness(FComposerData CurrentComposerData, TArray<FComposerData> ComposerDataSet, FLetsGoGeneratedScale Scale) override;
+	virtual float GetStrategyAppropriateness(FComposerData CurrentComposerData, const AMusicComposerState* State) override;
 	virtual float
-	GetInstrumentAppropriateness(FComposerData CurrentComposerData, TArray<FComposerData> ComposerDataSet) override;
+	GetInstrumentAppropriateness(FComposerData CurrentComposerData, const AMusicComposerState* State) override;
 };

--- a/Source/LETSGO/MusicEngine/MusicComposition/Strategy_PedalPointComposition.h
+++ b/Source/LETSGO/MusicEngine/MusicComposition/Strategy_PedalPointComposition.h
@@ -17,8 +17,8 @@ class LETSGO_API UStrategy_PedalPointComposition : public UObject, public IMusic
 	GENERATED_BODY()
 
 public:
-	virtual FInstrumentSchedule Apply(FComposerData& ComposerData, FInstrumentScheduleData InstrumentScheduleData) override;
-	virtual float GetStrategyAppropriateness(FComposerData CurrentComposerData, const AMusicComposerState* State) override;
+	virtual FInstrumentSchedule Apply(TSharedPtr<FComposerData> CurrentComposerData, FInstrumentScheduleData InstrumentScheduleData) override;
+	virtual float GetStrategyAppropriateness(TSharedPtr<FComposerData> CurrentComposerData, const AMusicComposerState* State) override;
 	virtual float
-	GetInstrumentAppropriateness(FComposerData CurrentComposerData, const AMusicComposerState* State) override;
+	GetInstrumentAppropriateness(TSharedPtr<FComposerData> CurrentComposerData, const AMusicComposerState* State) override;
 };

--- a/Source/LETSGO/MusicEngine/MusicComposition/Strategy_PedalPointComposition.h
+++ b/Source/LETSGO/MusicEngine/MusicComposition/Strategy_PedalPointComposition.h
@@ -17,7 +17,7 @@ class LETSGO_API UStrategy_PedalPointComposition : public UObject, public IMusic
 	GENERATED_BODY()
 
 public:
-	virtual FInstrumentSchedule Apply(TSharedPtr<FComposerData> CurrentComposerData, FInstrumentScheduleData InstrumentScheduleData) override;
+	virtual FPerBarSchedule GenerateBar(TSharedPtr<FComposerData> CurrentComposerData, const AMusicComposerState* State) override;
 	virtual float GetStrategyAppropriateness(TSharedPtr<FComposerData> CurrentComposerData, const AMusicComposerState* State) override;
 	virtual float
 	GetInstrumentAppropriateness(TSharedPtr<FComposerData> CurrentComposerData, const AMusicComposerState* State) override;

--- a/Source/LETSGO/MusicEngine/ULetsGoMusicEngine.cpp
+++ b/Source/LETSGO/MusicEngine/ULetsGoMusicEngine.cpp
@@ -3,6 +3,34 @@
 
 #include "LETSGO/MusicEngine/ULetsGoMusicEngine.h"
 
+void FLetsGoGeneratedScale::GenerateScale(const FLetsGoMusicNotes& InTonic, const FLetsGoMusicScale& Scale)
+{
+	Notes = TArray
+	{
+		InTonic,
+	};
+	
+	FLetsGoMusicNotes CurrentNote = InTonic;
+		
+	for (FLetsGoMusicScaleStep i : Scale.Steps)
+	{
+		// Get whole = 2 half = 1
+		const int Step = i.Step.GetValue();
+			
+		// Get next step, wrap around to beginning if >12
+		int Next = (CurrentNote.Note.GetValue() + Step) % 12;
+			
+		// Get the Note enum at position "Next"
+		FLetsGoMusicNotes NextNote = FLetsGoMusicNotes(static_cast<ELetsGoMusicNotes>(Next));
+			
+		// Add to Scale
+		Notes.Add(NextNote);
+			
+		// Update CurrentNote for next iteration
+		CurrentNote = NextNote;
+	}
+}
+
 ULetsGoMusicEngine::ULetsGoMusicEngine()
 {
 }
@@ -170,29 +198,6 @@ FLetsGoGeneratedScale ULetsGoMusicEngine::GenerateScale(const FLetsGoMusicScale&
 {
 	FLetsGoGeneratedScale GeneratedScale = FLetsGoGeneratedScale(Tonic, Scale);
 	
-	GeneratedScale.Notes = TArray<FLetsGoMusicNotes>();
-	GeneratedScale.Notes.Add(Tonic);
-	
-	FLetsGoMusicNotes CurrentNote = Tonic;
-		
-	for (FLetsGoMusicScaleStep i : Scale.Steps)
-	{
-		// Get whole = 2 half = 1
-		const int Step = i.Step.GetValue();
-			
-		// Get next step, wrap around to beginning if >12
-		int Next = (CurrentNote.Note.GetValue() + Step) % 12;
-			
-		// Get the Note enum at position "Next"
-		FLetsGoMusicNotes NextNote = FLetsGoMusicNotes(static_cast<ELetsGoMusicNotes>(Next));
-			
-		// Add to Scale
-		GeneratedScale.Notes.Add(NextNote);
-			
-		// Update CurrentNote for next iteration
-		CurrentNote = NextNote;
-	}
-
 	return GeneratedScale;
 }
 
@@ -229,22 +234,15 @@ TArray<FLetsGoGeneratedScale> ULetsGoMusicEngine::GenerateAllScales(const FLetsG
 //          2nd      3rd      4th     5th      6th   7th
 // "{ C, [Db, D], [Eb, E], [Fb, F], [G, G#], [A, A#], B }"
 //    1  ♯1   2    ♯2  3    4♯  4    5  ♯5    6 ♯6    7  (Chromatic Scale Intervals)
-
-// C + 2 [ +1, +2 ] <- 3rds
-
-//   1   ♯1  2    ♯2  3    4♯  4    5  ♯5    6 ♯6   7  
-// "{A, [A♯, B], [C, C♯], [D, D♯], [E, F], [F♯, G], G♯ }"
-//        2nd      3rd      4th      5th     6th    7th 
-TArray<FLetsGoMusicNotes> ULetsGoMusicEngine::GetInterval(const FLetsGoMusicNotes Tonic, const int DesiredInterval)
+TArray<int> ULetsGoMusicEngine::GetInterval(const int DesiredInterval)
 {
-	//                       5th                3    Scale[6] = F
+	// Get one less than the Desired interval 
+	// ex. 5th IntervalBase = Scale[6] (D# if Tonic = C)
 	const int IntervalBase = (DesiredInterval - 2) * 2;
 
-	// return {F + 1, F + 2}
-	FLetsGoGeneratedScale ChromaticScale = GenerateScale(Chromatic, Tonic);
 	TArray Interval = {
-		ChromaticScale.Notes[IntervalBase + 1], // 7 = "G" or "E" depending on Tonics C, A respectively
-		ChromaticScale.Notes[IntervalBase + 2]  // 8 = "G#" or "F"
+		IntervalBase + 1, // Scale[7] = "G" for Tonic = C
+		IntervalBase + 2  // Scale[8] = "G#"
 	};
 
 	return Interval;

--- a/Source/LETSGO/MusicEngine/ULetsGoMusicEngine.h
+++ b/Source/LETSGO/MusicEngine/ULetsGoMusicEngine.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "LETSGO/LETSGO.h"
 #include "ULetsGoMusicEngine.generated.h"
 
 const FString LetsGoBlueprintCategory = FString("LetsGo Music Theory");
@@ -100,19 +101,29 @@ struct FLetsGoGeneratedScale
 	FLetsGoMusicNotes Tonic;
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite)
-	FLetsGoMusicScale Scale;
-
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
 	TArray<FLetsGoMusicNotes> Notes;
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
-	bool IsValid = false;
+	FLetsGoGeneratedScale() {}
 
-	FLetsGoGeneratedScale() : Tonic(), Scale(), Notes() {}
+	FLetsGoGeneratedScale(const TArray<FLetsGoMusicNotes>& InNotes)
+	{
+		if (InNotes.Num() == 0)
+		{
+			UE_LOG(LogLetsgo, Error, TEXT("FLetsGoGeneratedScale constructed with 0 sized Note array"))
+			FLetsGoGeneratedScale();
+		} else
+		{
+			Notes = InNotes;
+			Tonic = Notes[0];
+		}
+	}
 
-	FLetsGoGeneratedScale(const FLetsGoMusicNotes& Tonic, const FLetsGoMusicScale& Scale, const TArray<FLetsGoMusicNotes>& Notes) : Tonic(Tonic), Scale(Scale), Notes(Notes), IsValid(true) {}
+	FLetsGoGeneratedScale(const FLetsGoMusicNotes& Tonic, const FLetsGoMusicScale& Scale) : Tonic(Tonic)
+	{
+		GenerateScale(Tonic, Scale);
+	}
 
-	FLetsGoGeneratedScale(const FLetsGoMusicNotes& Tonic, const FLetsGoMusicScale& Scale) : Tonic(Tonic), Scale(Scale), IsValid(true) {}
+	void GenerateScale(const FLetsGoMusicNotes& Tonic, const FLetsGoMusicScale& Scale);
 };
 
 /**
@@ -150,10 +161,9 @@ public:
 	UFUNCTION(BlueprintCallable, Category= LetsGoBlueprintCategory)
 	static TArray<FLetsGoGeneratedScale> GenerateAllScales(const FLetsGoMusicNotes& Tonic);
 
-	/// Given a Tonic ("C") and Interval ("3rd"), retrieve the possible notes for that Interval 
-	/// @param Tonic Key of the Scale
+	/// Given an Interval ("3rd"), retrieve the possible indices for that Interval in a Chromatic Scale
 	/// @param DesiredInterval int of the degree of the scale 
-	/// @return Array of possible notes for desired Interval
+	/// @return Array of possible chromatic scale indices for desired Interval
 	UFUNCTION(BlueprintCallable, Category= LetsGoBlueprintCategory)
-	static TArray<FLetsGoMusicNotes> GetInterval(const FLetsGoMusicNotes Tonic, const int DesiredInterval);
+	static TArray<int> GetInterval(const int DesiredInterval);
 };

--- a/Source/LETSGO/Phases/PhaseManager.cpp
+++ b/Source/LETSGO/Phases/PhaseManager.cpp
@@ -41,6 +41,10 @@ void APhaseManager::BeginPlay()
 	AStartMusicComposer* MusicComposer = World->SpawnActor<AStartMusicComposer>(StartMusicComposerClass);
 	MusicComposer->Initialize();
 	Phases.Emplace(MusicComposer);
+
+	AStartMusicConductor* MusicConductor = World->SpawnActor<AStartMusicConductor>(StartMusicConductorClass);
+	MusicConductor->Initialize();
+	Phases.Emplace(MusicConductor);
 	
 	AStartDrums* StartDrums = World->SpawnActor<AStartDrums>(StartDrumsClass);
 	StartDrums->Initialize();

--- a/Source/LETSGO/Phases/PhaseManager.h
+++ b/Source/LETSGO/Phases/PhaseManager.h
@@ -10,6 +10,7 @@
 #include "StartClock.h"
 #include "StartDrums.h"
 #include "StartMusicComposer.h"
+#include "StartMusicConductor.h"
 #include "UObject/Object.h"
 #include "PhaseManager.generated.h"
 
@@ -50,6 +51,9 @@ public:
 
 	UPROPERTY(BlueprintReadWrite, EditDefaultsOnly, Category="LETSGO")
 	TSubclassOf<AStartMusicComposer> StartMusicComposerClass; 
+
+	UPROPERTY(BlueprintReadWrite, EditDefaultsOnly, Category="LETSGO")
+	TSubclassOf<AStartMusicConductor> StartMusicConductorClass;
 	
 private:
 	// The last frame number we were ticked.
@@ -61,7 +65,6 @@ private:
 protected:
 	// Called when the game starts or when spawned
 	virtual void BeginPlay() override;
-	
 	
 public:
 	UFUNCTION()

--- a/Source/LETSGO/Phases/SetThird.h
+++ b/Source/LETSGO/Phases/SetThird.h
@@ -17,10 +17,7 @@ class LETSGO_API ASetThird : public AActor, public IPhaseController
 public:
 	// Sets default values for this actor's properties
 	ASetThird();
-
-	UPROPERTY()
-	FLetsGoMusicNotes Tonic;
-
+	
 	UPROPERTY()
 	AAudioPlatformSpawner* Spawner;
 
@@ -60,9 +57,6 @@ public:
 
 	UFUNCTION()
 	void Initialize();
-	
-	UFUNCTION()
-	void SetTonic();
 	
 	UFUNCTION()
 	void SetThird(FLetsGoMusicNotes Note);

--- a/Source/LETSGO/Phases/StartDrums.cpp
+++ b/Source/LETSGO/Phases/StartDrums.cpp
@@ -109,34 +109,36 @@ void AStartDrums::Initialize()
 		GEngine->AddOnScreenDebugMessage(-1, 15.0f, FColor::Yellow, EnumAsString);	
 	}
 
-
-
 	// Initialize Kick
 	Kick = GetWorld()->SpawnActorDeferred<AInstrument>(InstrumentClass, FTransform());
-	Kick->Initialize(Pattern.Kick, true);
+	Kick->InitializeSingleSchedule(Pattern.Kick);
 	Kick->FinishSpawning(FTransform());
 	
 	//Initialize Snare
 	Snare = GetWorld()->SpawnActorDeferred<AInstrument>(InstrumentClass, FTransform());
-	Snare->Initialize(Pattern.Snare, true);
+	Snare->InitializeSingleSchedule(Pattern.Snare);
 	Snare->FinishSpawning(FTransform());	
 
 	//Initialize HiHatOpen
 	HiHatOpen = GetWorld()->SpawnActorDeferred<AInstrument>(InstrumentClass, FTransform());
-	HiHatOpen->Initialize(Pattern.HiHatOpen, true);
+	HiHatOpen->InitializeSingleSchedule(Pattern.HiHatOpen);
 	HiHatOpen->FinishSpawning(FTransform());
 
 	//Initialize HiHatOpen
 	HiHatClosed = GetWorld()->SpawnActorDeferred<AInstrument>(InstrumentClass, FTransform());
-	HiHatClosed->Initialize(Pattern.HiHatClosed, true);
+	HiHatClosed->InitializeSingleSchedule(Pattern.HiHatClosed);
 	HiHatClosed->FinishSpawning(FTransform());
 
 	//Initialize Clap
 	Clap = GetWorld()->SpawnActorDeferred<AInstrument>(InstrumentClass, FTransform());
-	Clap->Initialize(Pattern.Clap, true);
+	Clap->InitializeSingleSchedule(Pattern.Clap);
 	Clap->FinishSpawning(FTransform());
-	
-	
+
+	Kick->Initialize(true);
+	Snare->Initialize(true);
+	HiHatOpen->Initialize(true);
+	HiHatClosed->Initialize(true);
+	Clap->Initialize(true);
 }
 
 
@@ -181,11 +183,7 @@ void AStartDrums::InitiateDestroy()
 void AStartDrums::OnQuantizationBoundaryTriggered(FName ClockName, EQuartzCommandQuantization QuantizationType,
 	int32 NumBars, int32 Beat, float BeatFraction)
 {
-	Kick->StartPlaying();
-	Snare->StartPlaying();
-	HiHatOpen->StartPlaying();
-	HiHatClosed->StartPlaying();
-	Clap->StartPlaying();
+
 	IsComplete = true;
 }
 

--- a/Source/LETSGO/Phases/StartDrums.cpp
+++ b/Source/LETSGO/Phases/StartDrums.cpp
@@ -113,27 +113,27 @@ void AStartDrums::Initialize()
 
 	// Initialize Kick
 	Kick = GetWorld()->SpawnActorDeferred<AInstrument>(InstrumentClass, FTransform());
-	Kick->Initialize(Pattern.Kick);
+	Kick->Initialize(Pattern.Kick, true);
 	Kick->FinishSpawning(FTransform());
 	
 	//Initialize Snare
 	Snare = GetWorld()->SpawnActorDeferred<AInstrument>(InstrumentClass, FTransform());
-	Snare->Initialize(Pattern.Snare);
+	Snare->Initialize(Pattern.Snare, true);
 	Snare->FinishSpawning(FTransform());	
 
 	//Initialize HiHatOpen
 	HiHatOpen = GetWorld()->SpawnActorDeferred<AInstrument>(InstrumentClass, FTransform());
-	HiHatOpen->Initialize(Pattern.HiHatOpen);
+	HiHatOpen->Initialize(Pattern.HiHatOpen, true);
 	HiHatOpen->FinishSpawning(FTransform());
 
 	//Initialize HiHatOpen
 	HiHatClosed = GetWorld()->SpawnActorDeferred<AInstrument>(InstrumentClass, FTransform());
-	HiHatClosed->Initialize(Pattern.HiHatClosed);
+	HiHatClosed->Initialize(Pattern.HiHatClosed, true);
 	HiHatClosed->FinishSpawning(FTransform());
 
 	//Initialize Clap
 	Clap = GetWorld()->SpawnActorDeferred<AInstrument>(InstrumentClass, FTransform());
-	Clap->Initialize(Pattern.Clap);
+	Clap->Initialize(Pattern.Clap, true);
 	Clap->FinishSpawning(FTransform());
 	
 	

--- a/Source/LETSGO/Phases/StartMusicConductor.cpp
+++ b/Source/LETSGO/Phases/StartMusicConductor.cpp
@@ -1,0 +1,64 @@
+﻿// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "StartMusicConductor.h"
+
+#include "LETSGO/GameModes/ALetsGoGameMode.h"
+
+
+// Sets default values
+AStartMusicConductor::AStartMusicConductor()
+{
+	// Set this actor to call Tick() every frame.  You can turn this off to improve performance if you don't need it.
+	PrimaryActorTick.bCanEverTick = true;
+}
+
+// Called when the game starts or when spawned
+void AStartMusicConductor::BeginPlay()
+{
+	Super::BeginPlay();
+	
+}
+
+// Called every frame
+void AStartMusicConductor::Tick(float DeltaTime)
+{
+	Super::Tick(DeltaTime);
+}
+
+void AStartMusicConductor::Initialize()
+{
+	Conductor = GetWorld()->SpawnActor<AMusicConductor>(MusicConductorClass);
+
+}
+
+void AStartMusicConductor::Activate()
+{
+	Conductor->Initialize();
+
+	Active = true;
+	Completed = true;
+}
+
+bool AStartMusicConductor::IsActivated()
+{
+	return Active;
+}
+
+void AStartMusicConductor::Deactivate()
+{
+}
+
+void AStartMusicConductor::Complete()
+{
+}
+
+bool AStartMusicConductor::IsCompleted()
+{
+	return Completed;
+}
+
+void AStartMusicConductor::InitiateDestroy()
+{
+}
+

--- a/Source/LETSGO/Phases/StartMusicConductor.h
+++ b/Source/LETSGO/Phases/StartMusicConductor.h
@@ -1,0 +1,57 @@
+﻿// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "PhaseController.h"
+#include "GameFramework/Actor.h"
+#include "LETSGO/MusicEngine/MusicComposition/MusicConductor.h"
+#include "StartMusicConductor.generated.h"
+
+UCLASS()
+class LETSGO_API AStartMusicConductor : public AActor, public IPhaseController
+{
+	GENERATED_BODY()
+
+public:
+	// Sets default values for this actor's properties
+	AStartMusicConductor();
+
+	UPROPERTY()
+	AMusicConductor* Conductor;
+
+	UPROPERTY(BlueprintReadWrite, EditDefaultsOnly, Category="LETSGO")
+	TSubclassOf<AMusicConductor> MusicConductorClass;
+
+protected:
+	// Called when the game starts or when spawned
+	virtual void BeginPlay() override;
+
+	bool Completed;
+	bool Active;
+
+public:
+	// Called every frame
+	virtual void Tick(float DeltaTime) override;
+	
+	UFUNCTION()
+	void Initialize();
+	
+	UFUNCTION()
+	virtual void Activate() override;
+	
+	UFUNCTION()
+	virtual bool IsActivated() override;
+
+	UFUNCTION()
+	virtual void Deactivate() override;
+
+	UFUNCTION()
+	virtual void Complete() override;
+
+	UFUNCTION()
+	virtual bool IsCompleted() override;
+
+	UFUNCTION()
+	virtual void InitiateDestroy() override;
+};


### PR DESCRIPTION
Refactor of #11 

## Game Mode

* Removed the "SetThird, SetFourth, SetFifth" methods
* Realized that all the scales are really just subsets of the Chromatic scale, so I can just use that and limit the notes that can be chosen from the Chromatic scale
* So now we throw around chromatic scale _indicies_ as opposed to actual notes (chromatic_scale[0] == tonic, etc.)
* Also pulled `GameState` into a property of `GameMode`, so I don't have to keeping calling the GetState method everytime its needed. 

## Composer State 
Move Composer state into a separate actor. 

* `MusicalStrategy` methods needs state, but I have no idea what state is needed. Having a separate `ComposerState` makes this easier. Just pass the whole stateful object and take what data (const readonly though) that's needed
* Also made `ComposerDataObjects` a `TSharedPtr`, as multiple objects need to read from this entity. 
  * Learned all about `TSharedPtr`, which is really cool. 
  * I had originally thought that there should be an original object that is made shared, but this isn't the case. 
  * Apparently `MakeShared()`, the method to create a TSharedPtr, _is_ the object. It's the constructor for the object, and everything that needs to reference can point to it. 
  * This is great, because `Instrument`, `MusicComposer`, and `MusicConductor` all need to use `InstrumentSchedules`

## Instrument + InstrumentSchedules  

As part of this refactor, I put `StartOnBar` into the `FInstrumentSchedule`. This was to flatten the ComposerData object, which had a lot of 2-3 property structs it was managing. It made things difficult to manage/reason about/etc. 

The implication of putting `StartOnBar` into the Instrument Schedule is that now Instruments can access that property. This enables us to have Instruments to play a set of InstrumentSchedules.

* Previously, `Instruments` only had a single `FInstrumentSchedule` and would play on demand
* Now, Instruments have a `TArray<FInstrumentSchedule>`. Instruments will match its `CurrentBar` to the `StartOnBar`, and play the schedule if appropriate. 

## MusicConductor

In an attempt to limit the scope of the `MusicComposer`, I wanted an entity that managed actually playing things. 

Specifically, I wanted MusicComposer to only be concerned with composing music- creating new InstrumentSchedules for different parts. (I've arbitrarily selected `Bass, Alto, Tenor, Soprano` as the initial parts)

So I created a `Conductor` Actor that manages the main clock to be used by Instruments/Composer. It also matches ComposerData to Instruments as well. 

I'm on the fence about this approach. It's a manager object that feels like a lot of overhead for what it's providing. 

## TODO

* Consider putting `AInstrument*` in `FInstrumentData`. If this works, it essentially removes the necessity of the Conductor completely. 
  * I am hesitant to put Actors as properties of structs though. Not exactly sure why. Bad vibes I guess. 

* Move Drums into Composer. 
  * This is a whole thing though. I mean, it wouldn't be too difficult, but refactors Drums out of `StartDrums` phase management and into something that the Composer manages. 
  * This is necessary though. Would allow drums to be evolved/modified, instead of the straight forward drum loops currently being managed. 

* Start adding Musical Strategies
  * Right now I just have a pedal point. Need to create "CreateMotif", "EvolveMotif", etc. 
  * This is the super fun part, really. As this is the core of the generative music of the game. Build up a series of MusicalStrategies, and have the Composer weigh the appropriateness of those strategies, to create a "not bad" musical composition. 
  * This kind of makes or breaks the entire LETSGO experiment, actually. If it just sounds bad, then the prototype is, technically, a failure. 
    * Slightly terrifying, as we're definitely crossed one year on working on this game. Which is wild to think about. 